### PR TITLE
[keep sync] Check source instead of genre when generating gpx data because genre is not limited to KeepApp (eg. can be AppleWatch)

### DIFF
--- a/scripts/keep_sync.py
+++ b/scripts/keep_sync.py
@@ -86,7 +86,7 @@ def parse_raw_data_to_nametuple(run_data, old_gpx_ids, with_download_gpx=False):
     keep_id = run_data["id"].split("_")[1]
 
     start_time = run_data["startTime"]
-    if run_data.get("vendor", {}).get("genre", "") == "KeepApp" and run_data.get(
+    if run_data.get("vendor", {}).get("source", "") == "Keep" and run_data.get(
         "rawDataURL"
     ):
         raw_data_url = run_data.get("rawDataURL")


### PR DESCRIPTION
#40 