### PR TITLE
Add `Publish GitHub Pages` workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,60 @@
+name: Publish GitHub Pages
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.4
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: |
+          yarn install
+      - run: |
+          yarn build --prefix-paths
+
+      - name: GitHub Pages
+        uses: crazy-max/ghaction-github-pages@v2.2.0
+        with:
+          # Git branch where site will be deployed
+          target_branch: gh-pages
+          # Create incremental commit instead of doing push force
+          keep_history: true
+          # Build directory to deploy
+          build_dir: public
+          # Write the given domain name to the CNAME file
+          #fqdn: custom.domain.name # optional
+          # Prevent Jekyll from building the site
+          jekyll: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,10 +2,8 @@ name: Publish GitHub Pages
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push events but only for the master branch
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/README-CN.md
+++ b/README-CN.md
@@ -38,7 +38,7 @@
 
 1. GitHub Actions 管理自动同步跑步进程及自动生成新的页面
 2. Gatsby 生成的静态网页，速度快
-3. 支持 Vercel(推荐) 自动部署
+3. 支持 Vercel(推荐) 和 GitHub Pages 自动部署
 4. React Hooks
 5. Mapbox 进行地图展示
 6. Nike 及 Runtastic(Adidas Run) 以及佳明（佳明中国）及 Keep 等, 自动备份 gpx 数据，方便备份及上传到其它软件

--- a/README-CN.md
+++ b/README-CN.md
@@ -27,7 +27,7 @@
 | [yvetterowe](https://github.com/yvetterowe) | https://run.haoluo.io | Strava |
 | [love-exercise](https://github.com/KaiOrange) | https://run.kai666666.top/ | Keep |
 | [zstone12](https://github.com/zstone12) | https://running-page.zstone12.vercel.app | Keep |
-| [Lax](https://github.com/Lax) | https://running-lax.vercel.app | Keep |
+| [Lax](https://github.com/Lax) | https://lax.github.io/running_page/ | Keep |
 | [lusuzi](https://github.com/lusuzi) | https://running.lusuzi.vercel.app | Nike |
 | [wh1994](https://github.com/wh1994) | https://run4life.fun | Garmin |
 ## 它是怎么工作的

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 1. GitHub Actions manages automatic synchronization of runs and generation of new pages.
 2. Gatsby-generated static pages, fast
-3. Support for Vercel (recommended) automated deployment
+3. Support for Vercel (recommended) and GitHub Pages automated deployment
 4. React Hooks
 5. Mapbox for map display
 6. Supports most sports apps such as nike strava...

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | [yvetterowe](https://github.com/yvetterowe) | https://run.haoluo.io | Strava |
 | [love-exercise](https://github.com/KaiOrange) | https://run.kai666666.top | Keep |
 | [zstone12](https://github.com/zstone12) | https://running-page.zstone12.vercel.app/ | Keep |
-| [Lax](https://github.com/Lax) | https://running-lax.vercel.app/ | Keep |
+| [Lax](https://github.com/Lax) | https://lax.github.io/running_page/ | Keep |
 | [lusuzi](https://github.com/lusuzi) | https://running.lusuzi.vercel.app | Nike |
 | [wh1994](https://github.com/wh1994) | https://run4life.fun | Garmin |
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  pathPrefix: `/`, // Change to `/running_page` when running on github pages
   siteMetadata: {
     title: 'Running page',
     siteUrl: 'https://yihong.run',


### PR DESCRIPTION
安装 workflow 后，下次更新 `master` 会触发自动部署到 GitHub Pages，默认 gh-pages 分支。

支持 2 种场景：
1. 使用自定义域名：workflow 中设置 fqdn
2. 使用项目目录：在 `gatsby-config.js` 设置 `pathPrefix`

