### PR TITLE
Update GitHub Pages workflow with documentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,6 +5,20 @@ on:
   # Triggers the workflow on push events but only for the master branch
   push:
     branches: [ master ]
+    paths:
+      - .github/workflows/gh-pages.yml
+      - package.json
+      - yarn.lock
+      - gatsby-config.js
+      - gatsby-node.js
+      - assets/*.svg
+      - src/**.js
+      - src/**.jsx
+      - src/**.scss
+      - src/**.json
+
+  schedule:
+    - cron: "5 0 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README-CN.md
+++ b/README-CN.md
@@ -27,7 +27,7 @@
 | [yvetterowe](https://github.com/yvetterowe) | https://run.haoluo.io | Strava |
 | [love-exercise](https://github.com/KaiOrange) | https://run.kai666666.top/ | Keep |
 | [zstone12](https://github.com/zstone12) | https://running-page.zstone12.vercel.app | Keep |
-| [Lax](https://github.com/Lax) | https://lax.github.io/running_page/ | Keep |
+| [Lax](https://github.com/Lax) | https://lax.github.io/running/ | Keep |
 | [lusuzi](https://github.com/lusuzi) | https://running.lusuzi.vercel.app | Nike |
 | [wh1994](https://github.com/wh1994) | https://run4life.fun | Garmin |
 ## 它是怎么工作的

--- a/README-CN.md
+++ b/README-CN.md
@@ -433,6 +433,18 @@ https://github.com/flopp/GpxTrackPoster
 3. 访问
 </details>
 
+<details>
+<summary> 部署到 GitHub Pages </summary>
+
+1. 配置 GitHub Action。如需使用自定义域名，可以修改 [.github/workflows/gh-pages.yml](.github/workflows/gh-pages.yml) 中的 `fqdn`（默认已注释掉）
+
+2. 修改 `gatsby-config.js`，更新 `pathPrefix`。【如果使用自定义域名，可跳过这一步】
+
+3. 在项目的 `Actions -> Workflows -> All Workflows` 中选择 Publish GitHub Pages，点击 `Run workflow`
+
+4. 在项目的 `Settings -> GitHub Pages -> Source` 部分，选择 `Branch: gh-pages` 并点击 `Save`。
+</details>
+
 ## GitHub Actions (Fork 的同学请一定不要忘了把 GitHub Token 改成自己的，否则会 push 到我的 repo 中，谢谢大家。)
 
 <details>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | [yvetterowe](https://github.com/yvetterowe) | https://run.haoluo.io | Strava |
 | [love-exercise](https://github.com/KaiOrange) | https://run.kai666666.top | Keep |
 | [zstone12](https://github.com/zstone12) | https://running-page.zstone12.vercel.app/ | Keep |
-| [Lax](https://github.com/Lax) | https://lax.github.io/running_page/ | Keep |
+| [Lax](https://github.com/Lax) | https://lax.github.io/running/ | Keep |
 | [lusuzi](https://github.com/lusuzi) | https://running.lusuzi.vercel.app | Nike |
 | [wh1994](https://github.com/wh1994) | https://run4life.fun | Garmin |
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,18 @@ https://github.com/flopp/GpxTrackPoster
 
 </details>
 
+<details>
+<summary> Deploy to GitHub Pages </summary>
+
+1. If you are using a custom domain for GitHub Pages, open [.github/workflows/gh-pages.yml](.github/workflows/gh-pages.yml), change `fqdn` value to the domain name of your site.
+
+2. (*Skip this step if you're **NOT** using a custom domain*) Modify `gatsby-config.js`, change `pathPrefix` value to the root path. If the repository name is `running_page`, the value will be `/running_page`.
+
+3. Go to repository's `Actions -> Workflows -> All Workflows`, choose `Publish GitHub Pages` from the left panel, click `Run workflow`. Make sure the workflow runs without errors, and `gh-pages` branch is created.
+
+4. Go to repository's `Settings -> GitHub Pages -> Source`, choose `Branch: gh-pages`, click `Save`.
+</details>
+
 ## GitHub Actions 
 
 <details>


### PR DESCRIPTION
研究了 GitHub Actions 的文档，发现在 workflow 中使用 `secrets.GITHUB_TOKEN` 创建新的 commit，push 到仓库之后不会触发 workflow（为了防止无限死循环）。由于这个原因，执行完之前的 Sync Data workflow 之后，不会触发自动执行这一个 workflow。
可以通过使用用户级别的 GitHub user token 来来代替仓库级别的 GITHUB_TOKEN，避免这个问题，但是也会带来更多的配置步骤。

因此，为了方便，直接把这个 workflow 加进了定时任务，在 Sync Data 之后 5 分钟执行，省去了 token 的配置，应该能满足大部分用户的需求。

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
