### PR TITLE
修复 YearsStat 组件中点击 Total YearStat 会出现两个Total YearStat (一上一下) 的 bug

### DIFF
--- a/src/components/YearsStat/index.jsx
+++ b/src/components/YearsStat/index.jsx
@@ -7,6 +7,7 @@ const YearsStat = ({ year, onClick }) => {
   const { years } = useActivities();
   // make sure the year click on front
   let yearsArrayUpdate = years.slice();
+  yearsArrayUpdate.push('Total');
   yearsArrayUpdate = yearsArrayUpdate.filter((x) => x !== year);
   yearsArrayUpdate.unshift(year);
 
@@ -23,7 +24,9 @@ const YearsStat = ({ year, onClick }) => {
       {yearsArrayUpdate.map((year) => (
         <YearStat key={year} year={year} onClick={onClick} />
       ))}
-      <YearStat key="Total" year="Total" onClick={onClick} />
+      {yearsArrayUpdate.hasOwnProperty('Total') ?
+        <YearStat key="Total" year="Total" onClick={onClick} /> : <div/>
+      }
     </div>
   );
 };


### PR DESCRIPTION
以下两个 Total YearStat 同时存在
![image](https://user-images.githubusercontent.com/61317160/117251015-a6a2e780-ae76-11eb-8a1a-65e6df14b1e2.png)
![image](https://user-images.githubusercontent.com/61317160/117251032-ae628c00-ae76-11eb-95f8-b49138295dd3.png)
