### PR TITLE
feat: add copy svg copy command

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,6 +54,8 @@ jobs:
           yarn install
       - run: |
           yarn build --prefix-paths
+      - run: |
+          cp -r assets/ public/static
 
       - name: GitHub Pages
         uses: crazy-max/ghaction-github-pages@v2.2.0


### PR DESCRIPTION
#106 
对这个 issues 讨论后，可以在 GitHub Action 中加一个复制命令，用来将静态的 svg 复制出来，便于使用自定义域名访问静态文件，