### PR TITLE
修复 Site Title 显示的问题

### DIFF
--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -13,7 +13,7 @@ const Layout = ({ children }) => {
     <div>
       <Helmet bodyAttributes={{ class: styles.body }}>
         <html lang="en" />
-        <title>{title}</title>
+        <title>{siteTitle}</title>
         <meta name="description" content={description} />
         <meta name="keywords" content="running" />
         <meta

--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -13,7 +13,7 @@ const Layout = ({ children }) => {
     <div>
       <Helmet bodyAttributes={{ class: styles.body }}>
         <html lang="en" />
-        {/* <title>{title}</title> */}
+        <title>{title}</title>
         <meta name="description" content={description} />
         <meta name="keywords" content="running" />
         <meta
@@ -21,7 +21,6 @@ const Layout = ({ children }) => {
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
       </Helmet>
-      <Header title={siteTitle} />
       <div className="pa3 pa5-l">{children}</div>
     </div>
   );


### PR DESCRIPTION
更新到 @shaonianche 昨晚最新的  https://github.com/yihong0618/running_page/commit/0a63cc178baf35b586a368ab5ace4fff363f9ac4 之后，发现这一行并没有生效

https://github.com/yihong0618/running_page/blob/7769ebafbfb2a4b06410ff8d49be68842b27943d/src/components/Layout/index.jsx#L24

所以对其进行了删除，恢复了原本的 title 显示，更正了新的变量名称，经测试在我自己的网站上显示正常。