### PR TITLE
fix: typo

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -6,7 +6,7 @@ R.I.P. 希望大家都能健康顺利的跑过终点，逝者安息。
 
 # [打造个人跑步主页](https://yihong.run/running)
 
-[English](README-EN.md) | 简体中文 | [Wiki](https://wiki.mfydev.run/)
+[English](README.md) | 简体中文 | [Wiki](https://wiki.mfydev.run/)
 
 <details>
 <summary>GIF 展示</summary>


### PR DESCRIPTION
并不存在 `README-EN.md` 应该是指向`README.md`