### PR TITLE
strava向Garmin同步时使用原始的数据格式

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -96,12 +96,12 @@ jobs:
       - name: Run sync Strava to Garmin(Run with strava(or others upload to strava) data backup in Garmin)
         if: env.RUN_TYPE == 'strava_to_garmin'
         run: |
-          python scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GRAMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }}
+          python scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GRAMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }}  ${{ secrets.STRAVA_EMAIL }} ${{ secrets.GSTRAVA_PASSWORD }}
   
       - name: Run sync Strava to Garmin-cn(Run with strava(or others upload to strava) data backup in Garmin-cn)
         if: env.RUN_TYPE == 'strava_to_garmin_cn'
         run: |
-          python scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GRAMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }} --is-cn
+          python scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GRAMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }}  ${{ secrets.STRAVA_EMAIL }} ${{ secrets.GSTRAVA_PASSWORD }} --is-cn
 
       - name: Make svg GitHub profile
         if: env.RUN_TYPE != 'pass'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ timezonefinder
 pyyaml
 aiofiles
 cloudscraper
+stravaweblib
 
 # Ci
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ timezonefinder
 pyyaml
 aiofiles
 cloudscraper
+stravaweblib

--- a/scripts/strava_to_garmin_sync.py
+++ b/scripts/strava_to_garmin_sync.py
@@ -1,13 +1,15 @@
 import argparse
 import asyncio
+import pytz
 from io import BytesIO
 import gpxpy
 from xml.etree import ElementTree
 import gpxpy.gpx
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from utils import make_strava_client
 from garmin_sync import Garmin
 from strava_sync import run_strava_sync
+from stravaweblib import WebClient, DataFormat
 
 from config import STRAVA_GARMIN_TYPE_DICT
 
@@ -72,7 +74,7 @@ def make_gpx_from_points(title, points_dict_list):
     return gpx.to_xml()
 
 
-async def upload_to_activities(garmin_client, strava_client):
+async def upload_to_activities(garmin_client, strava_client, strava_web_client):
     last_activity = await garmin_client.get_activities(0, 1)
     if not last_activity:
         filters = {}
@@ -80,23 +82,21 @@ async def upload_to_activities(garmin_client, strava_client):
         # is this startTimeGMT must have ?
         after_datetime_str = last_activity[0]["startTimeGMT"]
         after_datetime = datetime.strptime(after_datetime_str, "%Y-%m-%d %H:%M:%S")
+        after_datetime = (
+            after_datetime.replace(tzinfo=timezone.utc)
+            .astimezone(tz=pytz.timezone("Asia/Shanghai"))
+            .strftime("%Y-%m-%d %H:%M:%S")
+        )
+        print(after_datetime)
         filters = {"after": after_datetime}
     strava_activities = list(strava_client.get_activities(**filters))
     files_list = []
     # strava rate limit
     for i in strava_activities[:50]:
-        start_time = i.start_date
-        activity_type = i.type
-        # strava steams types info from strava api doc
-        types = ["time", "latlng", "altitude", "heartrate", "velocity_smooth", "temp"]
-        s = strava_client.get_activity_streams(i.id, types=types, resolution="medium")
-        points = generate_strava_run_points(start_time, s)
-        if points:
-            garmin_type = STRAVA_GARMIN_TYPE_DICT.get(activity_type, "running")
-            gpx_doc = make_gpx_from_points("test", points)
-            file = BytesIO(bytes(gpx_doc, "utf8"))
-            files_list.append((file, garmin_type))
-    await garmin_client.upload_activities(files_list)
+        print(i.id)
+        data = strava_web_client.get_activity_data(i.id, fmt=DataFormat.ORIGINAL)
+        files_list.append(data)
+    await garmin_client.upload_activities_fit(files_list)
     return files_list
 
 
@@ -107,6 +107,8 @@ if __name__ == "__main__":
     parser.add_argument("strava_refresh_token", help="strava refresh token")
     parser.add_argument("garmin_email", nargs="?", help="email of garmin")
     parser.add_argument("garmin_password", nargs="?", help="password of garmin")
+    parser.add_argument("strava_email", nargs="?", help="email of strava")
+    parser.add_argument("strava_password", nargs="?", help="password of strava")
     parser.add_argument(
         "--is-cn",
         dest="is_cn",
@@ -119,13 +121,21 @@ if __name__ == "__main__":
         options.strava_client_secret,
         options.strava_refresh_token,
     )
+    strava_web_client = WebClient(
+        access_token=strava_client.access_token,
+        email=options.strava_email,
+        password=options.strava_password,
+    )
+
     garmin_auth_domain = "CN" if options.is_cn else ""
 
     garmin_client = Garmin(
         options.garmin_email, options.garmin_password, garmin_auth_domain
     )
     loop = asyncio.get_event_loop()
-    future = asyncio.ensure_future(upload_to_activities(garmin_client, strava_client))
+    future = asyncio.ensure_future(
+        upload_to_activities(garmin_client, strava_client, strava_web_client)
+    )
     loop.run_until_complete(future)
 
     # Run the strava sync


### PR DESCRIPTION
测试了garmin的上传url，好像和文件格式不强关联
由于strava的原始文件格式也不一定时fit格式，所以这地方我就没改了，还是用.gpx后缀的url。
测试了两天，数据上传到garmin后，都能正常同步数据到悦跑圈和Keep的。