### PR TITLE
Ingore doubtful activity from keep.

### DIFF
--- a/scripts/keep_sync.py
+++ b/scripts/keep_sync.py
@@ -44,8 +44,10 @@ def get_to_download_runs_ids(session, headers):
         r = session.get(RUN_DATA_API.format(last_date=last_date), headers=headers)
         if r.ok:
             run_logs = r.json()["data"]["records"]
+
             for i in run_logs:
-                result.extend(j["stats"]["id"] for j in i["logs"])
+                logs = [j["stats"] for j in i["logs"]]
+                result.extend(k['id'] for k in logs if not k['isDoubtful'])
             last_date = r.json()["data"]["lastTimestamp"]
             since_time = datetime.utcfromtimestamp(last_date / 1000)
             print(f"pares keep ids data since {since_time}")


### PR DESCRIPTION
If synced with multiple source, for example, use both garmin
and keep record the workout, if we enable sync garmin in keep,
the result maybe doubled.

Use hte `isDoubtful` field to check the logs.