### PR TITLE
fix: cloudscraper 1.2.60 break on python 3.6, use 1.2.58 instead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ sqlalchemy
 timezonefinder
 pyyaml
 aiofiles
-cloudscraper
+cloudscraper==1.2.58


### PR DESCRIPTION
Garmin sync GitHub Actions run well until cloudscraper latest version `1.2.60` release 12 days ago. 
![image](https://user-images.githubusercontent.com/6956444/160289408-e29979f6-3a6a-4efb-8845-08bfb358eab0.png)
![image](https://user-images.githubusercontent.com/6956444/160289816-f851341d-047a-453a-b6ec-d6921cbc2ca7.png)

Look like the new version break on python `3.6`.
Setting to use last version `1.2.58` for now.  Test Passed.

If the problem won't fix with python `3.6` and the old version fail to bypass Cloudflare, maybe we have to upgrade to python `3.7`.