### PR TITLE
optimize docker workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+./node_modules
+./.cache

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
-./node_modules
-./.cache
+.git
+node_modules
+.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM python:3.10.5-slim AS develop-py
 WORKDIR /root/running_page
 COPY ./requirements.txt /root/running_page/requirements.txt
-RUN pip3 install -i https://mirrors.aliyun.com/pypi/simple/ pip -U
-RUN pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple/
-RUN pip3 install -r requirements.txt
+RUN pip3 install -i https://mirrors.aliyun.com/pypi/simple/ pip -U \
+        && pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple/ \
+        && pip3 install -r requirements.txt
 
 FROM node:14  AS develop-node
 WORKDIR /root/running_page

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
-FROM python:3.10.5-slim AS data
+
+FROM python:3.10.5-slim AS develop-py
+WORKDIR /root/running_page
+COPY ./requirements.txt /root/running_page/requirements.txt
+RUN pip3 install -i https://mirrors.aliyun.com/pypi/simple/ pip -U
+RUN pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple/
+RUN pip3 install -r requirements.txt
+
+FROM node:14  AS develop-node
+WORKDIR /root/running_page
+COPY ./package.json /root/running_page/package.json
+COPY ./yarn.lock /root/running_page/yarn.lock
+RUN npm config set registry https://registry.npm.taobao.org \
+        && yarn install
+
+
+FROM develop-py AS data
 ARG app
 ARG nike_refresh_token
 ARG email
@@ -7,12 +23,13 @@ ARG client_id
 ARG client_secret
 ARG refresch_token
 ARG YOUR_NAME
+
 WORKDIR /root/running_page
-COPY . /root/running_page
-RUN pip3 install -i https://mirrors.aliyun.com/pypi/simple/ pip -U
-RUN pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple/
-RUN pip3 install -r requirements.txt
-RUN if [ "$app" = "NRC" ] ; then \
+COPY . /root/running_page/
+ARG DUMMY=unknown
+RUN DUMMY=${DUMMY}; \
+    echo $app ; \
+    if [ "$app" = "NRC" ] ; then \
        python3 scripts/nike_sync.py ${nike_refresh_token}; \
     elif [ "$app" = "Garmin" ] ; then \
          python3 scripts/garmin_sync.py ${email} ${password}; \
@@ -25,17 +42,16 @@ RUN if [ "$app" = "NRC" ] ; then \
     else \
         echo "Unknown app" ; \
     fi
-RUN python3 scripts/gen_svg.py --from-db --title "my running page" --type grid --athlete "$YOUR_NAME" --output assets/grid.svg --min-distance 10.0 --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime
-RUN python3 scripts/gen_svg.py --from-db --title "my running page" --type github --athlete "$YOUR_NAME" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
-RUN python3 scripts/gen_svg.py --from-db --type circular --use-localtime
+RUN python3 scripts/gen_svg.py --from-db --title "my running page" --type grid --athlete "$YOUR_NAME" --output assets/grid.svg --min-distance 10.0 --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime \
+        && python3 scripts/gen_svg.py --from-db --title "my running page" --type github --athlete "$YOUR_NAME" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5 \
+        && python3 scripts/gen_svg.py --from-db --type circular --use-localtime
 
-FROM node:14  AS frontend
-WORKDIR /root/
-COPY --from=data /root/running_page /root/
-RUN npm config set registry https://registry.npm.taobao.org
-RUN yarn install
+
+FROM develop-node AS frontend-build
+WORKDIR /root/running_page
+COPY --from=data /root/running_page /root/running_page
 RUN yarn build
 
 FROM nginx:alpine AS web
-COPY --from=frontend /root/public /usr/share/nginx/html/
-COPY --from=frontend /root/assets /usr/share/nginx/html/assets
+COPY --from=frontend-build /root/running_page/public /usr/share/nginx/html/
+COPY --from=frontend-build /root/running_page/assets /usr/share/nginx/html/assets

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "data:clean": "rm scripts/data.db GPX_OUT/* activities/* src/static/activities.json",
     "data:download:garmin": "python3 scripts/garmin_sync.py",
     "data:analysis": "python3 scripts/gen_svg.py --from-db --type github --output assets/github.svg",
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve --prefix-paths",
     "lint": "eslint --ext .js,.jsx src --fix",
     "check": "npx prettier --write *.{js,jsx,scss,json,md,yaml}",
     "ci": "yarn run check && yarn run build && yarn run test"


### PR DESCRIPTION
1. `dockerfile` should use it's cache properly, build docker image would fast than ever before.
2. `build` and `serve` flow in `package.json` use `--prefix-paths` as default, option `pathPrefix` in `gatsby-config.js` should be setting manually. (NOTE: if adopting this commit "83f23413a03afdac33607afff92aecca97642480", `gatsby-config.js`'s  `pathPrefix` should be annotated? I'm not familiar with front-end QAQ), it just a workaround for me by using `nginx`'s redirects to `docker`)