### PR TITLE
fix305

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,23 +2,11 @@ name: Publish GitHub Pages
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push events but only for the master branch
-  push:
-    branches: [ master ]
-    paths:
-      - .github/workflows/gh-pages.yml
-      - package.json
-      - yarn.lock
-      - gatsby-config.js
-      - gatsby-node.js
-      - assets/*.svg
-      - src/**.js
-      - src/**.jsx
-      - src/**.scss
-      - src/**.json
-
-  schedule:
-    - cron: "5 0 * * *"
+  # trigger when the Run Data Sync workflow succeeded
+  workflow_run:
+    workflows: ["Run Data Sync"]
+    types:
+      - completed
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with: 
-          token: ${{ secrets.PAT }}
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with: 
+          token: ${{ secrets.PAT }}
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/README-CN.md
+++ b/README-CN.md
@@ -56,7 +56,6 @@ R.I.P. 希望大家都能健康顺利的跑过终点，逝者安息。
 | [zhubao315](https://github.com/zhubao315)       | <https://zhubao315.github.io/running>        | Strava    |
 | [Jason Tan](https://github.com/Jason-cqtan)     | <https://jason-cqtan.github.io/running_page> | Nike      |
 | [Conge](https://github.com/conge)               | <https://conge.github.io/running_page>       | Strava      |
-| [cvvz](https://github.com/cvvz)                 | <https://cvvz.github.io/running>             | Keep      |
 
 ## 它是怎么工作的
 
@@ -406,11 +405,17 @@ python3(python) scripts/nike_sync.py eyJhbGciThiMTItNGIw******
 <details>
 <summary>获取 Strava 数据</summary>
 
-2. 修改 `gatsby-config.js`，更新 `pathPrefix`。【如果使用自定义域名，可跳过这一步】
+1. 注册/登陆 [Strava](https://www.strava.com/) 账号
+2. 登陆成功后打开 [Strava Developers](http://developers.strava.com) -> [Create & Manage Your App](https://strava.com/settings/api)
 
-3. 在项目的 `Actions -> Workflows -> All Workflows` 中选择 Publish GitHub Pages，点击 `Run workflow`
+3. 创建 `My API Application`
+   输入下列信息：
+   ![My API Application](https://raw.githubusercontent.com/shaonianche/gallery/master/running_page/strava_settings_api.png)
+   创建成功：
+   ![](https://raw.githubusercontent.com/shaonianche/gallery/master/running_page/created_successfully_1.png)
+4. 使用以下链接请求所有权限
+   将 ${your_id} 替换为 My API Application 中的 Client ID 后访问完整链接
 
-4. 在项目的 `Settings -> GitHub Pages -> Source` 部分，选择 `Branch: gh-pages` 并点击 `Save`。
 ```
 https://www.strava.com/oauth/authorize?client_id=${your_id}&response_type=code&redirect_uri=http://localhost/exchange_token&approval_prompt=force&scope=read_all,profile:read_all,activity:read_all,profile:write,activity:write
 ```
@@ -605,13 +610,11 @@ python3(python) scripts/gen_svg.py --from-db --type circular --use-localtime
 
 1. 配置 GitHub Action。如需使用自定义域名，可以修改 [.github/workflows/gh-pages.yml](.github/workflows/gh-pages.yml) 中的 `fqdn`（默认已注释掉）
 
-2. 按照[官方文档](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)创建一个PAT，并在项目的 `Settings -> Secrets -> Actions` 中新增一个名为`PAT`的secret，值为该PAT的值。
+2. 修改 `gatsby-config.js`，更新 `pathPrefix`。【如果使用自定义域名，可跳过这一步】
 
-3. 修改 `gatsby-config.js`，更新 `pathPrefix`。【如果使用自定义域名，可跳过这一步】
+3. 在项目的 `Actions -> Workflows -> All Workflows` 中选择 Publish GitHub Pages，点击 `Run workflow`
 
-4. 在项目的 `Actions -> Workflows -> All Workflows` 中选择 Publish GitHub Pages，点击 `Run workflow`
-
-5. 在项目的 `Settings -> GitHub Pages -> Source` 部分，选择 `Branch: gh-pages` 并点击 `Save`。
+4. 在项目的 `Settings -> GitHub Pages -> Source` 部分，选择 `Branch: gh-pages` 并点击 `Save`。
 
 </details>
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -56,6 +56,7 @@ R.I.P. 希望大家都能健康顺利的跑过终点，逝者安息。
 | [zhubao315](https://github.com/zhubao315)       | <https://zhubao315.github.io/running>        | Strava    |
 | [Jason Tan](https://github.com/Jason-cqtan)     | <https://jason-cqtan.github.io/running_page> | Nike      |
 | [Conge](https://github.com/conge)               | <https://conge.github.io/running_page>       | Strava      |
+| [cvvz](https://github.com/cvvz)                 | <https://cvvz.github.io/running>             | Keep      |
 
 ## 它是怎么工作的
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -406,17 +406,11 @@ python3(python) scripts/nike_sync.py eyJhbGciThiMTItNGIw******
 <details>
 <summary>获取 Strava 数据</summary>
 
-1. 注册/登陆 [Strava](https://www.strava.com/) 账号
-2. 登陆成功后打开 [Strava Developers](http://developers.strava.com) -> [Create & Manage Your App](https://strava.com/settings/api)
+2. 修改 `gatsby-config.js`，更新 `pathPrefix`。【如果使用自定义域名，可跳过这一步】
 
-3. 创建 `My API Application`
-   输入下列信息：
-   ![My API Application](https://raw.githubusercontent.com/shaonianche/gallery/master/running_page/strava_settings_api.png)
-   创建成功：
-   ![](https://raw.githubusercontent.com/shaonianche/gallery/master/running_page/created_successfully_1.png)
-4. 使用以下链接请求所有权限
-   将 ${your_id} 替换为 My API Application 中的 Client ID 后访问完整链接
+3. 在项目的 `Actions -> Workflows -> All Workflows` 中选择 Publish GitHub Pages，点击 `Run workflow`
 
+4. 在项目的 `Settings -> GitHub Pages -> Source` 部分，选择 `Branch: gh-pages` 并点击 `Save`。
 ```
 https://www.strava.com/oauth/authorize?client_id=${your_id}&response_type=code&redirect_uri=http://localhost/exchange_token&approval_prompt=force&scope=read_all,profile:read_all,activity:read_all,profile:write,activity:write
 ```

--- a/README-CN.md
+++ b/README-CN.md
@@ -56,7 +56,7 @@ R.I.P. 希望大家都能健康顺利的跑过终点，逝者安息。
 | [zhubao315](https://github.com/zhubao315)       | <https://zhubao315.github.io/running>        | Strava    |
 | [Jason Tan](https://github.com/Jason-cqtan)     | <https://jason-cqtan.github.io/running_page> | Nike      |
 | [Conge](https://github.com/conge)               | <https://conge.github.io/running_page>       | Strava      |
-| [cvvz](https://github.com/cvvz)                 | <https://cvvz.github.io/running>             | Keep      |
+| [cvvz](https://github.com/cvvz)                 | <https://cvvz.github.io/running>             | Strava      |
 
 ## 它是怎么工作的
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -56,6 +56,7 @@ R.I.P. 希望大家都能健康顺利的跑过终点，逝者安息。
 | [zhubao315](https://github.com/zhubao315)       | <https://zhubao315.github.io/running>        | Strava    |
 | [Jason Tan](https://github.com/Jason-cqtan)     | <https://jason-cqtan.github.io/running_page> | Nike      |
 | [Conge](https://github.com/conge)               | <https://conge.github.io/running_page>       | Strava      |
+| [cvvz](https://github.com/cvvz)                 | <https://cvvz.github.io/running>             | Keep      |
 
 ## 它是怎么工作的
 
@@ -610,11 +611,13 @@ python3(python) scripts/gen_svg.py --from-db --type circular --use-localtime
 
 1. 配置 GitHub Action。如需使用自定义域名，可以修改 [.github/workflows/gh-pages.yml](.github/workflows/gh-pages.yml) 中的 `fqdn`（默认已注释掉）
 
-2. 修改 `gatsby-config.js`，更新 `pathPrefix`。【如果使用自定义域名，可跳过这一步】
+2. 按照[官方文档](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)创建一个PAT，并在项目的 `Settings -> Secrets -> Actions` 中新增一个名为`PAT`的secret，值为该PAT的值。
 
-3. 在项目的 `Actions -> Workflows -> All Workflows` 中选择 Publish GitHub Pages，点击 `Run workflow`
+3. 修改 `gatsby-config.js`，更新 `pathPrefix`。【如果使用自定义域名，可跳过这一步】
 
-4. 在项目的 `Settings -> GitHub Pages -> Source` 部分，选择 `Branch: gh-pages` 并点击 `Save`。
+4. 在项目的 `Actions -> Workflows -> All Workflows` 中选择 Publish GitHub Pages，点击 `Run workflow`
+
+5. 在项目的 `Settings -> GitHub Pages -> Source` 部分，选择 `Branch: gh-pages` 并点击 `Save`。
 
 </details>
 


### PR DESCRIPTION
Fixes #305 

[github action 限制只有使用PAT的workflow才能触发另一个workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow )，所以在data sync 的workflow中配置使用PAT。