### PR TITLE
fix: no attribute 'summary_polyline'

### DIFF
--- a/scripts/generator/db.py
+++ b/scripts/generator/db.py
@@ -109,7 +109,9 @@ def update_or_create_activity(session, run_activity):
                 location_country=location_country,
                 average_heartrate=run_activity.average_heartrate,
                 average_speed=float(run_activity.average_speed),
-                summary_polyline=run_activity.map.summary_polyline,
+                summary_polyline=(
+                    run_activity.map and run_activity.map.summary_polyline or ""
+                ),
             )
             session.add(activity)
             created = True
@@ -121,7 +123,9 @@ def update_or_create_activity(session, run_activity):
             activity.type = run_activity.type
             activity.average_heartrate = run_activity.average_heartrate
             activity.average_speed = float(run_activity.average_speed)
-            activity.summary_polyline = run_activity.map.summary_polyline
+            activity.summary_polyline = (
+                run_activity.map and run_activity.map.summary_polyline or ""
+            )
     except Exception as e:
         print(f"something wrong with {run_activity.id}")
         print(str(e))


### PR DESCRIPTION
The healthfit synced Apple Watch record to Strava but no `summary_polyline`.


```
Run python scripts/strava_sync.py *** *** ***
Access ok
Start syncing
something wrong with 7796808006
'NoneType' object has no attribute 'summary_polyline'
.something wrong with 7804774185
'NoneType' object has no attribute 'summary_polyline'
.something wrong with 7817409219
'NoneType' object has no attribute 'summary_polyline'
.
```