### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Set Variables
       id: set_variables
       run: |
-        echo "::set-output name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-        echo "::set-output name=PIP_CACHE::$(pip cache dir)"
+        echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
+        echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache PIP
       uses: actions/cache@v2
       with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Set Variables
         id: set_variables
         run: |
-          echo "::set-output name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-          echo "::set-output name=PIP_CACHE::$(pip cache dir)"
+          echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
+          echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache PIP
         uses: actions/cache@v2


### PR DESCRIPTION
GitHub deprecated set-output command, recommend using GITHUB_OUTPUT environment file instead:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Current warnings in [CI](https://github.com/yihong0618/running_page/actions/runs/3238756532/jobs/5307320860):
![image](https://user-images.githubusercontent.com/10510431/195605056-aff7fd83-1e42-43bd-ab42-35a71d4db15f.png)
