### PR TITLE
fix: avoid merging for different types

### DIFF
--- a/scripts/gpxtrackposter/track_loader.py
+++ b/scripts/gpxtrackposter/track_loader.py
@@ -128,7 +128,7 @@ class TrackLoader:
                 merged_tracks.append(t)
             else:
                 dt = (t.start_time_local - last_end_time).total_seconds()
-                if 0 < dt < 3600:
+                if 0 < dt < 3600 and merged_tracks[-1].type == t.type:
                     merged_tracks[-1].append(t)
                 else:
                     merged_tracks.append(t)


### PR DESCRIPTION
`track_loader` would merge activities within 1 hour, but it didn't consider the `type`.
In some cases, eg. in Triathlon, people swimming/cycling/running in a row. 
I've added the condition for the same type. This feature is important for `workouts_page` users but maybe is not that important for `running_page` users, close this PR if you think that. 
