### PR TITLE
fix: Mapbox 'zh' is not working while package 'mapbox-gl-language' upgraded

### DIFF
--- a/src/components/RunMap/index.jsx
+++ b/src/components/RunMap/index.jsx
@@ -1,5 +1,5 @@
 import MapboxLanguage from '@mapbox/mapbox-gl-language';
-import React from 'react';
+import React, { useRef, useCallback } from 'react';
 import ReactMapGL, { Layer, Source } from 'react-map-gl';
 import useActivities from 'src/hooks/useActivities';
 import {
@@ -25,21 +25,19 @@ const RunMap = ({
   mapButtonYear,
 }) => {
   const { provinces } = useActivities();
-  const addControlHandler = (event) => {
-    const map = event && event.target;
-    // set lauguage to Chinese if you use English please comment it
-    if (map && IS_CHINESE) {
-      map.addControl(
-        new MapboxLanguage({
-          defaultLanguage: 'zh',
-        })
-      );
-      map.setLayoutProperty('country-label-lg', 'text-field', [
-        'get',
-        'name_zh',
-      ]);
-    }
-  };
+  const mapRef = useRef();
+  const mapRefCallback = useCallback(
+    (ref) => {
+      if (ref !== null) {
+        mapRef.current = ref;
+        const map = ref.getMap();
+        if (map && IS_CHINESE) {
+          map.addControl(new MapboxLanguage({ defaultLanguage: 'zh-Hans' }));
+        }
+      }
+    },
+    [mapRef]
+  );
   const filterProvinces = provinces.slice();
   // for geojson format
   filterProvinces.unshift('in', 'name');
@@ -66,9 +64,9 @@ const RunMap = ({
   return (
     <ReactMapGL
       {...viewport}
-      mapStyle="mapbox://styles/mapbox/dark-v9"
+      mapStyle="mapbox://styles/mapbox/dark-v10"
       onViewportChange={setViewport}
-      onLoad={addControlHandler}
+      ref={mapRefCallback}
       mapboxApiAccessToken={MAPBOX_TOKEN}
     >
       <RunMapButtons


### PR DESCRIPTION
A bug was introduced for dependency '@mapbox/mapbox-gl-language' upgraded to 1.0.0
This causes Mapbox Chinese not to show properly, I did a little refactoring to suit the package upgrade.

* Adds support for Mapbox Streets v8 vector tileset and all styles based on this tileset, such as streets-v11 and dark-v10 while removing support for Mapbox Streets v7 vector tileset-based styles. 
   * upgrade dark-v9 -> dark-v10
* Support for Streets v7 Chinese zh is replaced with Traditional Chinese zh-Hant and Simplified Chinese zh-Hans. 
  * `zh` -> `zh-Hans`
  
ref: https://github.com/mapbox/mapbox-gl-language/releases/tag/v1.0.0