### PR TITLE
fix: 解决佳明数据同步出现402 Client Error: Payment异常问题

### DIFF
--- a/scripts/garmin_sync.py
+++ b/scripts/garmin_sync.py
@@ -70,6 +70,7 @@ class Garmin:
         self.headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
             "origin": self.URL_DICT.get("SSO_URL_ORIGIN"),
+            "nk": "NT",
         }
         self.is_only_running = is_only_running
         self.upload_url = self.URL_DICT.get("UPLOAD_URL")


### PR DESCRIPTION
解决佳明数据同步出现402 Client Error: Payment异常问题