### PR TITLE
fix: python:3.10.5-slim image not has git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 FROM python:3.10.5-slim AS develop-py
 WORKDIR /root/running_page
 COPY ./requirements.txt /root/running_page/requirements.txt
-RUN pip3 install -i https://mirrors.aliyun.com/pypi/simple/ pip -U \
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends git \
+        && apt-get purge -y --auto-remove \
+        && rm -rf /var/lib/apt/lists/* \
+        && pip3 install -i https://mirrors.aliyun.com/pypi/simple/ pip -U \
         && pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple/ \
         && pip3 install -r requirements.txt
 


### PR DESCRIPTION
python:3.10.5-slim image does not have git package installed, so pip install will fail by git+https://github.com/alenrajsp/tcxreader.git