### PR TITLE
城市分割问题修改

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -58,6 +58,18 @@ const scrollToMap = () => {
   window.scroll(rect.left + window.scrollX, rect.top + window.scrollY);
 };
 
+const pattern = /([\u4e00-\u9fa5]{2,}(市|自治州))/g;
+const extractLocations = (str) => {
+  const locations = [];
+  let match;
+  
+  while ((match = pattern.exec(str)) !== null) {
+    locations.push(match[0]);
+  }
+  
+  return locations;
+};
+
 const cities = chinaCities.map((c) => c.name);
 // what about oversea?
 const locationForRun = (run) => {
@@ -66,11 +78,14 @@ const locationForRun = (run) => {
   if (location) {
     // Only for Chinese now
     // should fiter 臺灣
-    const cityMatch = location.match(/[\u4e00-\u9fa5]{2,}(市|自治州)/);
+    const cityMatch = extractLocations(location);
     const provinceMatch = location.match(/[\u4e00-\u9fa5]{2,}(省|自治区)/);
+
     if (cityMatch) {
       [city] = cityMatch;
-      if (!cities.includes(city)) {
+	  city = cities.find(value => cityMatch.includes(value));
+	  
+      if (!city) {
         city = '';
       }
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -83,7 +83,7 @@ const locationForRun = (run) => {
 
     if (cityMatch) {
       [city] = cityMatch;
-	  city = cities.find(value => cityMatch.includes(value));
+	    city = cities.find(value => cityMatch.includes(value));
 	  
       if (!city) {
         city = '';


### PR DESCRIPTION
location数据较为复杂，amazfit拿到的是详细的地址
如：
桥东社区, 土主街道, 沙坪坝区, 重庆市主城都市区, 重庆市, 中国
邛海宾馆-晓楼, 海滨中路, 新村街道, 西昌市, 凉山彝族自治州, 四川省, 615000, 中国
原有函数会拿到“重庆市主城都市区、西昌市“进行对比，但是这俩不在城市里面，所以无法在彩蛋中统计
修改后的结果如下图，将包含市和自治州的都拿出来，然后再跟城市列表对比，取其中最先匹配到的
![image](https://github.com/yihong0618/running_page/assets/14172964/8e442f92-8f23-4695-847b-033625221572)
