### PR TITLE
refactor: use event delegation to handle all <rect> & <polyline> in the "Total" view.

### DIFF
--- a/src/components/Layout/style.module.scss
+++ b/src/components/Layout/style.module.scss
@@ -8,7 +8,6 @@
   h1,
   h3,
   h4,
-  li,
   a {
     color: $nike;
     text-decoration: none;

--- a/src/components/RunMap/RunMapButtons.jsx
+++ b/src/components/RunMap/RunMapButtons.jsx
@@ -1,36 +1,22 @@
 import React, { useEffect, useState } from 'react';
 import useActivities from 'src/hooks/useActivities';
-import { MAIN_COLOR } from 'src/utils/const';
 import styles from './style.module.scss';
 
-const RunMapButtons = ({ changeYear, thisYear, mapButtonYear }) => {
-  const elements = document.getElementsByClassName(styles.button);
+const RunMapButtons = ({ changeYear, thisYear }) => {
   const { years } = useActivities();
   const yearsButtons = years.slice();
   yearsButtons.push('Total');
-  const [index, setIndex] = useState(0);
-  const handleClick = (e, year) => {
-    const elementIndex = yearsButtons.indexOf(year);
-    e.target.style.color = MAIN_COLOR;
 
-    if (index !== elementIndex) {
-      elements[index].style.color = 'white';
-    }
-    setIndex(elementIndex);
-  };
   return (
     <div>
       <ul className={styles.buttons}>
         {yearsButtons.map((year) => (
           <li
             key={`${year}button`}
-            style={{ color: year === thisYear ? MAIN_COLOR : 'white' }}
-            year={year}
-            onClick={(e) => {
+            className={styles.button + ` ${year === thisYear ? styles.selected : ''}`}
+            onClick={() => {
               changeYear(year);
-              handleClick(e, year);
             }}
-            className={styles.button}
           >
             {year}
           </li>

--- a/src/components/RunMap/index.jsx
+++ b/src/components/RunMap/index.jsx
@@ -25,7 +25,6 @@ const RunMap = ({
   changeYear,
   geoData,
   thisYear,
-  mapButtonYear,
 }) => {
   const { provinces } = useActivities();
   const mapRef = useRef();
@@ -85,7 +84,6 @@ const RunMap = ({
       <RunMapButtons
         changeYear={changeYear}
         thisYear={thisYear}
-        mapButtonYear={mapButtonYear}
       />
       <FullscreenControl className={styles.fullscreenButton} />
       <Source id="data" type="geojson" data={geoData}>

--- a/src/components/RunMap/style.module.scss
+++ b/src/components/RunMap/style.module.scss
@@ -25,6 +25,10 @@
   font-family: $global-font-family;
 }
 
+.selected {
+  color: $nike;
+}
+
 .fullscreenButton {
   top: 0rem;
   right: 0rem;

--- a/src/components/RunTable/RunRow.jsx
+++ b/src/components/RunTable/RunRow.jsx
@@ -1,42 +1,29 @@
 import React from 'react';
-import { MAIN_COLOR } from 'src/utils/const';
 import { formatPace, titleForRun, formatRunTime } from 'src/utils/utils';
 import styles from './style.module.scss';
+import { element } from 'prop-types';
 
-const RunRow = ({ runs, run, locateActivity, runIndex, setRunIndex }) => {
+const RunRow = ({ elementIndex, locateActivity, run, runIndex, setRunIndex }) => {
   const distance = (run.distance / 1000.0).toFixed(2);
-  const pace = run.average_speed;
-
-  const paceParts = pace ? formatPace(pace) : null;
-
+  const paceParts = run.average_speed ? formatPace(run.average_speed) : null;
   const heartRate = run.average_heartrate;
-
   const runTime = formatRunTime(run.moving_time);
-
-  // change click color
-  const handleClick = (e, runs, run) => {
-    const elementIndex = runs.indexOf(run);
-    e.target.parentElement.style.color = 'red';
-
-    const elements = document.getElementsByClassName(styles.runRow);
-    if (runIndex !== -1 && elementIndex !== runIndex) {
-      elements[runIndex].style.color = MAIN_COLOR;
-    }
+  const handleClick = (e) => {
+    console.log(runIndex, elementIndex)
+    if (runIndex === elementIndex) return;
     setRunIndex(elementIndex);
+    locateActivity(run.start_date_local.slice(0, 10));
   };
 
   return (
     <tr
-      className={styles.runRow}
+      className={`${styles.runRow} ${runIndex === elementIndex ? styles.selected : ''}`}
       key={run.start_date_local}
-      onClick={(e) => {
-        handleClick(e, runs, run);
-        locateActivity(run);
-      }}
+      onClick={handleClick}
     >
       <td>{titleForRun(run)}</td>
       <td>{distance}</td>
-      {pace && <td>{paceParts}</td>}
+      {paceParts && <td>{paceParts}</td>}
       <td>{heartRate && heartRate.toFixed(0)}</td>
       <td>{runTime}</td>
       <td className={styles.runDate}>{run.start_date_local}</td>

--- a/src/components/RunTable/index.jsx
+++ b/src/components/RunTable/index.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { MAIN_COLOR } from 'src/utils/const';
 import {
   sortDateFunc,
   sortDateFuncReverse,
@@ -43,18 +42,13 @@ const RunTable = ({
     ['Time', sortRunTimeFunc],
     ['Date', sortDateFuncClick],
   ]);
+
   const handleClick = (e) => {
     const funcName = e.target.innerHTML;
-    if (sortFuncInfo === funcName) {
-      setSortFuncInfo('');
-    } else {
-      setSortFuncInfo(funcName);
-    }
-    const f = sortFuncMap.get(e.target.innerHTML);
-    if (runIndex !== -1) {
-      const el = document.getElementsByClassName(styles.runRow);
-      el[runIndex].style.color = MAIN_COLOR;
-    }
+    const f = sortFuncMap.get(funcName);
+
+    setRunIndex(-1)
+    setSortFuncInfo(sortFuncInfo === funcName ? '' : funcName);
     setActivity(runs.sort(f));
   };
 
@@ -65,19 +59,19 @@ const RunTable = ({
           <tr>
             <th />
             {Array.from(sortFuncMap.keys()).map((k) => (
-              <th key={k} onClick={(e) => handleClick(e)}>
+              <th key={k} onClick={handleClick}>
                 {k}
               </th>
             ))}
           </tr>
         </thead>
         <tbody>
-          {runs.map((run) => (
+          {runs.map((run, elementIndex) => (
             <RunRow
-              runs={runs}
-              run={run}
               key={run.run_id}
+              elementIndex={elementIndex}
               locateActivity={locateActivity}
+              run={run}
               runIndex={runIndex}
               setRunIndex={setRunIndex}
             />

--- a/src/components/RunTable/style.module.scss
+++ b/src/components/RunTable/style.module.scss
@@ -41,6 +41,10 @@
   }
 }
 
+.selected {
+  color: red;
+}
+
 .tableContainer {
   width: 100%;
   overflow-x: scroll;

--- a/src/components/SVGStat/index.jsx
+++ b/src/components/SVGStat/index.jsx
@@ -4,7 +4,7 @@ import GridSvg from 'assets/grid.svg';
 import styles from './style.module.scss';
 
 const SVGStat = () => (
-  <div>
+  <div id="svgStat">
     <GitHubSvg className={styles.runSVG} />
     <GridSvg className={styles.runSVG} />
   </div>

--- a/src/components/Stat/index.jsx
+++ b/src/components/Stat/index.jsx
@@ -5,8 +5,8 @@ const divStyle = {
   fontWeight: '700',
 };
 
-const Stat = ({ value, description, className, citySize, onClick }) => (
-  <div className={`${className} pb2 w-100`} onClick={onClick}>
+const Stat = ({ value, description, className = 'pb2 w-100', citySize, onClick }) => (
+  <div className={`${className}`} onClick={onClick}>
     <span className={`f${citySize || 1} fw9 i`} style={divStyle}>
       {intComma(value)}
     </span>

--- a/src/components/YearStat/index.jsx
+++ b/src/components/YearStat/index.jsx
@@ -62,11 +62,7 @@ const YearStat = ({ year, onClick }) => {
         <Stat value={runs.length} description=" Runs" />
         <Stat value={sumDistance} description=" KM" />
         <Stat value={avgPace} description=" Avg Pace" />
-        <Stat
-          value={`${streak} day`}
-          description=" Streak"
-          className="mb0 pb0"
-        />
+        <Stat value={`${streak} day`} description=" Streak" />
         {hasHeartRate && (
           <Stat value={avgHeartRate} description=" Avg Heart Rate" />
         )}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -42,11 +42,8 @@ const Index = () => {
   const changeByItem = (item, name, func, isChanged) => {
     scrollToMap();
     setActivity(filterAndSortRuns(activities, item, func, sortDateFunc));
-    // if the year not change, we do not need to setYear
-    if (!isChanged) {
-      setRunIndex(-1);
-      setTitle(`${item} ${name} Running Heatmap`);
-    }
+    setRunIndex(-1);
+    setTitle(`${item} ${name} Running Heatmap`);
   };
 
   const changeYear = (y) => {
@@ -72,9 +69,22 @@ const Index = () => {
     changeByItem(title, 'Title', filterTitleRuns, false);
   };
 
-  const locateActivity = (run) => {
-    setGeoData(geoJsonForRuns([run]));
-    setTitle(titleForShow(run));
+  const locateActivity = (runDate) => {
+    const activitiesOnDate = runs.filter((r) => r.start_date_local.slice(0, 10) === runDate);
+
+    if (!activitiesOnDate.length) {
+      return;
+    }
+
+    const sortedActivities = activitiesOnDate.sort((a, b) => b.distance - a.distance);
+    const info = sortedActivities[0];
+
+    if (!info) {
+      return;
+    }
+
+    setGeoData(geoJsonForRuns([info]));
+    setTitle(titleForShow(info));
     clearInterval(intervalId);
     scrollToMap();
   };
@@ -102,65 +112,32 @@ const Index = () => {
     setIntervalId(id);
   }, [runs]);
 
-  // TODO refactor
   useEffect(() => {
     if (year !== 'Total') {
       return;
     }
 
-    let rectArr = document.querySelectorAll('rect');
-
-    if (rectArr.length !== 0) {
-      rectArr = Array.from(rectArr).slice(1);
+    let svgStat = document.getElementById('svgStat')
+    if (!svgStat) {
+      return
     }
+    svgStat.addEventListener('click', (e) => {
+      const target = e.target;
+      if (target) {
+        const tagName = target.tagName.toLowerCase()
 
-    rectArr.forEach((rect) => {
-      const rectColor = rect.getAttribute('fill');
-
-      // not run has no click event
-      if (rectColor !== '#444444') {
-        const runDate = rect.innerHTML;
-        // ingnore the error
-        const [runName] = runDate.match(/\d{4}-\d{1,2}-\d{1,2}/) || [];
-        const runLocate = runs
-          .filter((r) => r.start_date_local.slice(0, 10) === runName)
-          .sort((a, b) => b.distance - a.distance)[0];
-
-        // do not add the event next time
-        // maybe a better way?
-        if (runLocate) {
-          rect.addEventListener(
-            'click',
-            () => locateActivity(runLocate),
-            false
-          );
+        if ((tagName === 'rect' &&
+          parseFloat(target.getAttribute('width')) === 2.6 &&
+          parseFloat(target.getAttribute('height')) === 2.6 &&
+          target.getAttribute('fill') !== '#444444'
+        ) || (
+            tagName === 'polyline'
+          )) {
+          const [runDate] = target.innerHTML.match(/\d{4}-\d{1,2}-\d{1,2}/) || [`${+thisYear + 1}`];
+          locateActivity(runDate)
         }
       }
-    });
-    let polylineArr = document.querySelectorAll('polyline');
-
-    if (polylineArr.length !== 0) {
-      polylineArr = Array.from(polylineArr).slice(1);
-    }
-
-    // add picked runs svg event
-    polylineArr.forEach((polyline) => {
-      // not run has no click event
-      const runDate = polyline.innerHTML;
-      // `${+thisYear + 1}` ==> 2021
-      const [runName] = runDate.match(/\d{4}-\d{1,2}-\d{1,2}/) || [
-        `${+thisYear + 1}`,
-      ];
-      const run = runs
-        .filter((r) => r.start_date_local.slice(0, 10) === runName)
-        .sort((a, b) => b.distance - a.distance)[0];
-
-      // do not add the event next time
-      // maybe a better way?
-      if (run) {
-        polyline.addEventListener('click', () => locateActivity(run), false);
-      }
-    });
+    })
   }, [year]);
 
   return (
@@ -182,8 +159,6 @@ const Index = () => {
         </div>
         <div className="fl w-100 w-70-l">
           <RunMap
-            runs={runs}
-            year={year}
             title={title}
             viewport={viewport}
             geoData={geoData}
@@ -196,7 +171,6 @@ const Index = () => {
           ) : (
             <RunTable
               runs={runs}
-              year={year}
               locateActivity={locateActivity}
               setActivity={setActivity}
               runIndex={runIndex}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -6,6 +6,7 @@
 img::selection {
   background: transparent;
 }
+
 img::-moz-selection {
   background: transparent;
 }
@@ -99,9 +100,11 @@ a.post-colophon-link:visited {
 h2 .header-link {
   margin-top: 2rem;
 }
+
 h3 .header-link {
   margin-top: 2rem;
 }
+
 h5 .header-link {
   margin-top: -0.14rem;
 }
@@ -110,6 +113,7 @@ h5 .header-link {
   @extend .bg-light-gray;
 
   font-size: 0.875rem !important;
+
   &::-webkit-scrollbar {
     display: none;
   }


### PR DESCRIPTION
原本看到 Total 视图中给每个 `<react>` 和 `<polyline>` 都监听了 `click` 事件，数量极多，就用事件代理方式重构了一下，但影响到 `locateActivity` 方法在 `<RunRow>` 的调用，所以将 `locateActivity` 统一都改用 `runDate` 作为入参，最终由于关联改动的文件有 12 个，所以作为了一个提交。

主要调整如下：
1. 使用事件代理的方式重构 /pages/index.jsx 下有关 `<rect>` 和 `<polyline>` 的点击事件。
2. 调整 `locateActivity` 方法的入参为 `runDate`，仅在此方法被调用时从 `runs` 中查询当前 `run`。
3. 重构 `<RunMapButtons>`，使用 `className` 简化高亮年份，去除不必要的 `indexOf` 查找下标动作。
4. 在 `<RunRow>` 组件中使用 `className` 来高亮被点击的行，避免使用 `getElementsByClassName` 方式查询多余 tr 节点，提高性能。
5. 修复：当点击右侧列表某行后再点击左侧年份，右侧列表高亮行未消失，以及地图左下角的标题未更新。
    修复前：
    ![bug](https://github.com/yihong0618/running_page/assets/239585/ec2130f7-6f4f-4a11-98dd-c2517c1f65bb)

    修复后：
    ![2](https://github.com/yihong0618/running_page/assets/239585/df0c68ea-3604-4f81-8fb8-48546b93f70c)

6. 去除 ``<Stat value={`${streak} day`}`` 中无用的 className="mb0 pb0" 声明，`<Stat>` 组件设置 `className` 默认值为 "pb2 w-100"，避免渲染时出现 `undefined`。
    ![undefined](https://github.com/yihong0618/running_page/assets/239585/b65845a6-fd83-47ee-9148-6d57e010afec)
7. 去除 `<RunMap>` 和 `<RunTable>` 组件的 `mapButtonYear` `runs` `year` 等无用属性。
