### PR TITLE
[FEAT] add garmin device in strava_to_garmin_sync 

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -32,7 +32,7 @@ R.I.P. 希望大家都能健康顺利的跑过终点，逝者安息。
 | [ben_29](https://github.com/ben-29)               | <https://running.ben29.xyz>                    | Strava    |
 | [kcllf](https://github.com/kcllf)                 | <https://running-tau.vercel.app>               | Garmin-cn |
 | [mq](https://github.com/MQ-0707)                  | <https://running-iota.vercel.app>              | Keep      |
-| [zhaohongxuan](https://github.com/zhaohongxuan)   | <https://running-page-psi.vercel.app>          | Keep      |
+| [zhaohongxuan](https://github.com/zhaohongxuan)   | <https://zhaohongxuan.github.io/workouts>      | Strava    |
 | [yvetterowe](https://github.com/yvetterowe)       | <https://run.haoluo.io>                        | Strava    |
 | [love-exercise](https://github.com/KaiOrange)     | <https://run.kai666666.top>                    | Keep      |
 | [zstone12](https://github.com/zstone12)           | <https://running-page.zstone12.vercel.app>     | Keep      |
@@ -666,6 +666,19 @@ python3(python) scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }}
 
 ```python
 python3(python) scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }} ${{ secrets.STRAVA_EMAIL }} ${{ secrets.STRAVA_PASSWORD }} --is-cn
+```
+
+If you want to add Garmin Device during sync, you should add `--use_fake_garmin_device` argument, this will add a Garmin Device (Garmin Forerunner 245 by default, and you can change device in `garmin_device_adaptor.py`) in synced Garmin workout record, this is essential when you want to sync the workout record to other APP like Keep, JoyRun etc. and the final command will be:
+
+如果要在同步到Garmin的运动记录中添加Garmin设备信息，需要添加`--use_fake_garmin_device`参数，这将在同步的Garmin锻炼记录中添加一个Garmin设备（默认情况下为 `Garmin Forerunner 245`，您可以在`garmin_device_adaptor.py`中更改设备信息），运动记录中有了设备信息之后就可以同步到其他APP中，比如数字心动（攒上马积分）这类不能通过Apple Watch同步的APP，当然也可以同步到Keep，悦跑圈，咕咚等APP。
+
+<img width="830" alt="image" src="https://github.com/yihong0618/running_page/assets/8613196/b5076942-3133-4c89-ad66-a828211667dc">
+
+
+最终执行的命令如下：
+
+```python
+python3(python) scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }} ${{ secrets.STRAVA_EMAIL }} ${{ secrets.STRAVA_PASSWORD }} --use_fake_garmin_device
 ```
 
 注意：**首次初始化的时候，如果你有大量的 strava 跑步数据，可能有些数据会上传失败，只需要多重试几次即可。**

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ English | [简体中文](https://github.com/yihong0618/running_page/blob/master/
 | [ben_29](https://github.com/ben-29)               | <https://running.ben29.xyz>                    | Strava    |
 | [kcllf](https://github.com/kcllf)                 | <https://running-tau.vercel.app>               | Garmin-cn |
 | [mq](https://github.com/MQ-0707)                  | <https://running-iota.vercel.app>              | Keep      |
-| [zhaohongxuan](https://github.com/zhaohongxuan)   | <https://running-page-psi.vercel.app>          | Keep      |
+| [zhaohongxuan](https://github.com/zhaohongxuan)   | <https://zhaohongxuan.github.io/workouts>      | Strava    |
 | [yvetterowe](https://github.com/yvetterowe)       | <https://run.haoluo.io>                        | Strava    |
 | [love-exercise](https://github.com/KaiOrange)     | <https://run.kai666666.top>                    | Keep      |
 | [zstone12](https://github.com/zstone12)           | <https://running-page.zstone12.vercel.app>     | Keep      |
@@ -500,6 +500,16 @@ if your garmin account region is **China**, you need to execute the command:
 
 ```python
 python3(python) scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }} ${{ secrets.STRAVA_EMAIL }} ${{ secrets.STRAVA_PASSWORD }} --is-cn
+```
+
+If you want to add Garmin Device during sync, you should add `--use_fake_garmin_device` argument, this will add a Garmin Device (Garmin Forerunner 245 by default, and you can change device in `garmin_device_adaptor.py`) in synced Garmin workout record, this is essential when you want to sync the workout record to other APP like Keep, JoyRun etc. 
+
+<img width="830" alt="image" src="https://github.com/yihong0618/running_page/assets/8613196/b5076942-3133-4c89-ad66-a828211667dc">
+
+the final command will be:
+
+```python
+python3(python) scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }} ${{ secrets.STRAVA_EMAIL }} ${{ secrets.STRAVA_PASSWORD }} --use_fake_garmin_device
 ```
 
 ps: **when initializing for the first time, if you have a large amount of strava data, some data may fail to upload, just retry several times.**

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ stravaweblib
 tenacity
 numpy
 tzlocal
+fit-tool

--- a/scripts/garmin_device_adaptor.py
+++ b/scripts/garmin_device_adaptor.py
@@ -1,0 +1,71 @@
+import traceback
+
+from fit_tool.fit_file import FitFile
+from fit_tool.fit_file_builder import FitFileBuilder
+from fit_tool.profile.messages.device_info_message import DeviceInfoMessage
+from fit_tool.profile.messages.file_id_message import FileIdMessage
+from io import BytesIO
+
+# the device manufacturer and product info can be found in github,
+# https://github.com/garmin/fit-python-sdk/blob/main/garmin_fit_sdk/profile.py
+MANUFACTURER = 1  # Garmin
+GARMIN_DEVICE_PRODUCT_ID = 3415  # Forerunner 245
+GARMIN_SOFTWARE_VERSION = 3.58
+# The device serial number must be real Garmin will identify device with it
+# here the default number:1234567890 Garmin will recognize it as Forerunner 245
+GARMIN_DEVICE_SERIAL_NUMBER = 1234567890
+
+
+def is_fit_file(file):
+    file.seek(8)  # Move file pointer to the 9th byte
+    header = file.read(4)
+    file.seek(0)  # recover file pointer
+    return header == b".FIT"
+
+
+def wrap_device_info(origin_file):
+    try:
+        return do_wrap_device_info(origin_file)
+    except Exception:
+        print("wrap garmin device failed, will use origin file")
+        traceback.print_exc()
+        return BytesIO(origin_file.read())
+
+
+def do_wrap_device_info(origin_file):
+    """
+    add customized device info to fit file,
+    """
+    # if origin file is gpx file, skip
+    if not is_fit_file(origin_file):
+        return BytesIO(origin_file.read())
+
+    fit_file = FitFile.from_bytes(origin_file.read())
+    builder = FitFileBuilder(auto_define=True)
+
+    # Add custom Device Info
+    message = DeviceInfoMessage()
+    # the serial number must be real, otherwise Garmin will not identify it
+    message.serial_number = GARMIN_DEVICE_SERIAL_NUMBER
+    message.manufacturer = MANUFACTURER
+    message.garmin_product = GARMIN_DEVICE_PRODUCT_ID
+    message.software_version = GARMIN_SOFTWARE_VERSION
+    message.device_index = 0
+    message.source_type = 5
+    message.product = GARMIN_DEVICE_PRODUCT_ID
+    builder.add(message)
+
+    for record in fit_file.records:
+        message = record.message
+        if message.global_id == FileIdMessage.ID:
+            if isinstance(message, FileIdMessage):
+                message.manufacturer = MANUFACTURER
+                message.garmin_product = GARMIN_DEVICE_PRODUCT_ID
+                message.product = GARMIN_DEVICE_PRODUCT_ID
+                message.type = 4  # Activity
+
+        builder.add(message)
+
+    modified_file = builder.build()
+    print("wrap garmin device info sucess, product id:", GARMIN_DEVICE_PRODUCT_ID)
+    return modified_file.to_bytes()

--- a/scripts/garmin_sync.py
+++ b/scripts/garmin_sync.py
@@ -21,6 +21,7 @@ from io import BytesIO
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from utils import make_activities_file
+from garmin_device_adaptor import wrap_device_info
 
 # logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -218,8 +219,11 @@ class Garmin:
                 r.raise_for_status()
         await self.req.aclose()
 
-    async def upload_activities_original(self, datas):
-        print("start upload activities to garmin!!!")
+    async def upload_activities_original(self, datas, use_fake_garmin_device):
+        print(
+            "start upload activities to garmin!!!, use_fake_garmin_device:",
+            use_fake_garmin_device,
+        )
         if not self.is_login:
             self.login()
         for data in datas:
@@ -228,7 +232,12 @@ class Garmin:
                 for chunk in data.content:
                     f.write(chunk)
             f = open(data.filename, "rb")
-            files = {"data": (data.filename, BytesIO(f.read()))}
+            # wrap fake garmin device to origin fit file, current not support gpx file
+            if use_fake_garmin_device:
+                file_body = wrap_device_info(f)
+            else:
+                file_body = BytesIO(f.read())
+            files = {"data": (data.filename, file_body)}
 
             try:
                 res = await self.req.post(

--- a/scripts/garmin_sync.py
+++ b/scripts/garmin_sync.py
@@ -219,7 +219,7 @@ class Garmin:
                 r.raise_for_status()
         await self.req.aclose()
 
-    async def upload_activities_original(self, datas, use_fake_garmin_device):
+    async def upload_activities_original(self, datas, use_fake_garmin_device=False):
         print(
             "start upload activities to garmin!!!, use_fake_garmin_device:",
             use_fake_garmin_device,

--- a/scripts/strava_to_garmin_sync.py
+++ b/scripts/strava_to_garmin_sync.py
@@ -72,7 +72,9 @@ def make_gpx_from_points(title, points_dict_list):
     return gpx.to_xml()
 
 
-async def upload_to_activities(garmin_client, strava_client, strava_web_client, format):
+async def upload_to_activities(
+    garmin_client, strava_client, strava_web_client, format, use_fake_garmin_device
+):
     last_activity = await garmin_client.get_activities(0, 1)
     if not last_activity:
         print("no garmin activity")
@@ -97,7 +99,7 @@ async def upload_to_activities(garmin_client, strava_client, strava_web_client, 
             files_list.append(data)
         except Exception as ex:
             print("get strava data error: ", ex)
-    await garmin_client.upload_activities_original(files_list)
+    await garmin_client.upload_activities_original(files_list, use_fake_garmin_device)
     return files_list
 
 
@@ -115,6 +117,12 @@ if __name__ == "__main__":
         dest="is_cn",
         action="store_true",
         help="if garmin accout is cn",
+    )
+    parser.add_argument(
+        "--use_fake_garmin_device",
+        action="store_true",
+        default=False,
+        help="whether to use a faked Garmin device",
     )
     options = parser.parse_args()
     strava_client = make_strava_client(
@@ -136,7 +144,11 @@ if __name__ == "__main__":
         loop = asyncio.get_event_loop()
         future = asyncio.ensure_future(
             upload_to_activities(
-                garmin_client, strava_client, strava_web_client, DataFormat.ORIGINAL
+                garmin_client,
+                strava_client,
+                strava_web_client,
+                DataFormat.ORIGINAL,
+                options.use_fake_garmin_device,
             )
         )
         loop.run_until_complete(future)


### PR DESCRIPTION
## 在strava_to_garmin_sync中添加Garmin设备信息

添加Garmin设备信息的主要目的是使得可以通过Garmin间接得将运动记录同步到其他不支持Apple Watch的运动APP中，
比如`数字心动（上马）`，当然添加了设备信息之后，这些运动记录也可以同步运动记录到Keep，悦跑圈，咕咚等，但是需要注意在这些APP中，如果同时使用Apple Watch同步和Garmin同步的记录可能会重复。

<img width="816" alt="image" src="https://github.com/yihong0618/running_page/assets/8613196/ba668c5f-2dab-4405-b2d6-f0e49b4c99d4">

- 在strava_to_garmin_sync脚本中增加是否使用自定义Garmin设备的选项`--use_fake_garmin_device`，不加这个参数表示不启用
- 默认的Garmin设备的序列号是`1234567890`，Garmin 会将这个序列号识别为`Forerunner 245`，如果要更改设备，需要先获取真实Garmin设备序列号，在`garmin_device_adaptor.py`中修改 `GARMIN_DEVICE_SERIAL_NUMBER`的值
