### PR TITLE
feat(privacy): support hiding polyline start, end and choosing points

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -3,7 +3,7 @@ name: Run Data Sync
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
   push:
     branches:
       - master
@@ -28,6 +28,12 @@ env:
   TITLE_GRID: Over 10km Runs # also here
   GITHUB_NAME: yihong0618
   GITHUB_EMAIL: zouzou0208@gmail.com
+
+  # IGNORE_BEFORE_SAVING: True # if you want to ignore some data before saving, set this to True
+  IGNORE_START_END_RANGE: 10 # Unit meter
+  # Dont making this huge, just picking points you needing. https://developers.google.com/maps/documentation/utilities/polylineutility using this tool to making your polyline
+  IGNORE_POLYLINE: "ktjrFoemeU~IorGq}DeB"
+  IGNORE_RANGE: 10 # Unit meter
 
 jobs:
   sync:

--- a/README-CN.md
+++ b/README-CN.md
@@ -200,6 +200,22 @@ const USE_DASH_LINE = true;
 const LINE_OPACITY = 0.4;
 ```
 
+- 隐私保护：
+
+设置下面环境变量：
+
+```shell
+IGNORE_START_END_RANGE = 200 # 忽略每个 polyline 的起点和终点的距离（单位：米）。
+
+IGNORE_RANGE = 200 # 忽略下面 polyline 中每个点的距离（单位：米）。
+IGNORE_POLYLINE = ktjrFoemeU~IorGq}DeB # 包含要忽略的点的折线。 
+
+# 在保存到数据库之前进行过滤，你会丢失一些数据，但可以保护你的隐私，如果你使用的是公共仓库，建议设置为1。设置为 0 或不设置可关闭。
+IGNORE_BEFORE_SAVING = 1
+```
+
+你可一用[这个](https://developers.google.com/maps/documentation/utilities/polylineutility)，来制作你的 `IGNORE_POLYLINE`。如果你在中国，请使用卫星图制作，避免火星坐标漂移。
+
 ## 下载您的 Nike Run Club/Strava/Garmin/Garmin-cn/Keep 数据，[别忘了在 `total` 页面生成可视化 SVG](#total-data-analysis)
 
 ### GPX

--- a/README-CN.md
+++ b/README-CN.md
@@ -205,12 +205,12 @@ const LINE_OPACITY = 0.4;
 设置下面环境变量：
 
 ```shell
-IGNORE_START_END_RANGE = 200 # 忽略每个 polyline 的起点和终点的距离（单位：米）。
+IGNORE_START_END_RANGE = 200 # 忽略每个 polyline 的起点和终点的长度（单位：米）。
 
-IGNORE_RANGE = 200 # 忽略下面 polyline 中每个点的距离（单位：米）。
+IGNORE_RANGE = 200 # 忽略下面 polyline 中每个点的距离的圆圈（单位：米）。
 IGNORE_POLYLINE = ktjrFoemeU~IorGq}DeB # 包含要忽略的点的折线。 
 
-# 在保存到数据库之前进行过滤，你会丢失一些数据，但可以保护你的隐私，如果你使用的是公共仓库，建议设置为1。设置为 0 或不设置可关闭。
+# 在保存到数据库之前进行过滤，你会丢失一些数据，但可以保护你的隐私，如果你使用的是公共仓库，建议设置为1。不设置可关闭。
 IGNORE_BEFORE_SAVING = 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,22 @@ const USE_DASH_LINE = true;
 const LINE_OPACITY = 0.4;
 ```
 
+- privacy protection
+
+setting flowing env:
+```shell
+IGNORE_START_END_RANGE = 200 # ignore meters for each polyline start and end.
+
+IGNORE_RANGE = 200 # ignore meters for each point in below polyline. 
+IGNORE_POLYLINE = ktjrFoemeU~IorGq}DeB # a polyline include point you want to ignore. 
+
+# Do filter before saving to database, you will lose some data, but you can protect your privacy, when you using public repo. enable for set 1, disable for set 0 or unset it.
+IGNORE_BEFORE_SAVING = 1
+```
+
+You can using [this](https://developers.google.com/maps/documentation/utilities/polylineutility), to making your `IGNORE_POLYLINE`.
+
+
 ## Download your running data and do not forget to [generate svg in `total` page](#total-data-analysis)
 
 ### GPX

--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ const LINE_OPACITY = 0.4;
 
 setting flowing env:
 ```shell
-IGNORE_START_END_RANGE = 200 # ignore meters for each polyline start and end.
+IGNORE_START_END_RANGE = 200 # ignore distance for each polyline start and end.
 
 IGNORE_RANGE = 200 # ignore meters for each point in below polyline. 
 IGNORE_POLYLINE = ktjrFoemeU~IorGq}DeB # a polyline include point you want to ignore. 
 
-# Do filter before saving to database, you will lose some data, but you can protect your privacy, when you using public repo. enable for set 1, disable for set 0 or unset it.
-IGNORE_BEFORE_SAVING = 1
+# Do filter before saving to database, you will lose some data, but you can protect your privacy, when you using public repo. enable for set 1, disable via unset.
+IGNORE_BEFORE_SAVING = 
 ```
 
 You can using [this](https://developers.google.com/maps/documentation/utilities/polylineutility), to making your `IGNORE_POLYLINE`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ tenacity
 numpy
 tzlocal
 fit-tool
+haversine==2.8.0

--- a/scripts/gpxtrackposter/track.py
+++ b/scripts/gpxtrackposter/track.py
@@ -15,11 +15,15 @@ import s2sphere as s2
 from rich import print
 from tcxreader.tcxreader import TCXReader
 
+from polyline_processor import filter_out
+
 from .exceptions import TrackLoadError
 from .utils import parse_datetime_to_local
 
 start_point = namedtuple("start_point", "lat lon")
 run_map = namedtuple("polyline", "summary_polyline")
+
+IGNORE_BEFORE_SAVING = os.getenv("IGNORE_BEFORE_SAVING", False)
 
 
 class Track:
@@ -82,7 +86,8 @@ class Track:
         self.start_time_local = start_time
         self.end_time = start_time + activity.elapsed_time
         self.length = float(activity.distance)
-        summary_polyline = activity.summary_polyline
+        if not IGNORE_BEFORE_SAVING:
+            summary_polyline = filter_out(activity.summary_polyline)
         polyline_data = polyline.decode(summary_polyline) if summary_polyline else []
         self.polylines = [[s2.LatLng.from_degrees(p[0], p[1]) for p in polyline_data]]
 

--- a/scripts/polyline_processor.py
+++ b/scripts/polyline_processor.py
@@ -8,8 +8,13 @@ IGNORE_POLYLINE = (
     if os.getenv("IGNORE_POLYLINE")
     else []
 )
-IGNORE_RANGE = int(os.getenv("IGNORE_RANGE", "0")) / 1000
-IGNORE_START_END_RANGE = int(os.getenv("IGNORE_START_END_RANGE", "0")) / 1000
+
+try:
+    IGNORE_RANGE = int(os.getenv("IGNORE_RANGE", "0")) / 1000
+    IGNORE_START_END_RANGE = int(os.getenv("IGNORE_START_END_RANGE", "0")) / 1000
+except ValueError:
+    print("IGNORE_RANGE or IGNORE_START_END_RANGE is not a number")
+    exit(1)
 
 
 def point_distance_in_range(
@@ -40,7 +45,7 @@ def filter_out(polyline_str):
             continue
 
         new_pl.append(point)
-    if len(new_pl) == 0:
+    if not new_pl:
         return None
 
     return polyline.encode(new_pl)

--- a/scripts/polyline_processor.py
+++ b/scripts/polyline_processor.py
@@ -33,20 +33,17 @@ def point_in_list_points_range(
     return any([point_distance_in_range(point, p, distance) for p in points])
 
 
-def range_hidding(
+def range_hiding(
     polyline: List[Tuple[float]], points: List[Tuple[float]], distance: int
 ) -> List[Tuple[float]]:
-    new_polyline = []
-    for point in polyline:
-        if point_in_list_points_range(point, points, distance):
-            continue
-        new_polyline.append(point)
-    return new_polyline
+    return [
+        point
+        for point in polyline
+        if not point_in_list_points_range(point, points, distance)
+    ]
 
 
-def start_end_hidding(
-    polyline: List[Tuple[float]], distance: int
-) -> List[Tuple[float]]:
+def start_end_hiding(polyline: List[Tuple[float]], distance: int) -> List[Tuple[float]]:
     start_index, end_index = 0, len(polyline) - 1
 
     starting_distance = 0
@@ -74,8 +71,8 @@ def filter_out(polyline_str):
     if not pl:
         return polyline_str
 
-    new_pl = start_end_hidding(pl, IGNORE_START_END_RANGE)
-    new_pl = range_hidding(new_pl, IGNORE_POLYLINE, IGNORE_RANGE)
+    new_pl = start_end_hiding(pl, IGNORE_START_END_RANGE)
+    new_pl = range_hiding(new_pl, IGNORE_POLYLINE, IGNORE_RANGE)
 
     if not new_pl:
         return None

--- a/scripts/polyline_processor.py
+++ b/scripts/polyline_processor.py
@@ -1,0 +1,46 @@
+from typing import List, Tuple
+import polyline
+import os
+from haversine import haversine
+
+IGNORE_POLYLINE = (
+    polyline.decode(os.getenv("IGNORE_POLYLINE"))
+    if os.getenv("IGNORE_POLYLINE")
+    else []
+)
+IGNORE_RANGE = int(os.getenv("IGNORE_RANGE", "0")) / 1000
+IGNORE_START_END_RANGE = int(os.getenv("IGNORE_START_END_RANGE", "0")) / 1000
+
+
+def point_distance_in_range(
+    point: Tuple[float], center_point: Tuple[float], distance: int
+) -> bool:
+    return haversine(point, center_point) < distance
+
+
+def point_in_list_points_range(
+    point: Tuple[float], points: List[Tuple[float]], distance: int
+) -> bool:
+    return any([point_distance_in_range(point, p, distance) for p in points])
+
+
+def filter_out(polyline_str):
+    pl = polyline.decode(polyline_str)
+    if not pl:
+        return polyline_str
+    start_point, end_point = pl[0], pl[-1]
+
+    new_pl = []
+    for point in pl:
+        if point_in_list_points_range(
+            point, [start_point, end_point], IGNORE_START_END_RANGE
+        ):
+            continue
+        if point_in_list_points_range(point, IGNORE_POLYLINE, IGNORE_RANGE):
+            continue
+
+        new_pl.append(point)
+    if len(new_pl) == 0:
+        return None
+
+    return polyline.encode(new_pl)

--- a/scripts/polyline_processor.py
+++ b/scripts/polyline_processor.py
@@ -33,7 +33,9 @@ def point_in_list_points_range(
     return any([point_distance_in_range(point, p, distance) for p in points])
 
 
-def range_hidding(polyline: List[Tuple[float]], points: List[Tuple[float]], distance: int) -> List[Tuple[float]]:
+def range_hidding(
+    polyline: List[Tuple[float]], points: List[Tuple[float]], distance: int
+) -> List[Tuple[float]]:
     new_polyline = []
     for point in polyline:
         if point_in_list_points_range(point, points, distance):
@@ -71,10 +73,10 @@ def filter_out(polyline_str):
     pl = polyline.decode(polyline_str)
     if not pl:
         return polyline_str
-    
+
     new_pl = start_end_hidding(pl, IGNORE_START_END_RANGE)
     new_pl = range_hidding(new_pl, IGNORE_POLYLINE, IGNORE_RANGE)
-    
+
     if not new_pl:
         return None
 


### PR DESCRIPTION
**Little privacy enhancement**

Adding 4 environment variables to support hiding area for polyline start end and chosen points.

Using [this](https://developers.google.com/maps/documentation/utilities/polylineutility) to making `IGNORE_POLYLINE`.

```shell
IGNORE_START_END_RANGE = 200 # ignore meters for each polyline start and end.

IGNORE_RANGE = 200 # ignore meters for each point in the below polyline. 
IGNORE_POLYLINE = ktjrFoemeU~IorGq}DeB # a polyline include point you want to ignore. 

# Do filter before saving to the database, you will lose some data, but you can protect your privacy when you use public repo. enable for set 1, disable for set 0, or unset it.
IGNORE_BEFORE_SAVING = 1
```