### PR TITLE
在{FIT,GPX,TCX}_OUT三个文件夹添加数据文件出发同步脚本

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,11 @@ name: Publish GitHub Pages
 on:
   # trigger when the Run Data Sync workflow succeeded
   workflow_run:
-    workflows: ["Run Data Sync"]
+    workflows:
+      - "Run Data Sync"
+      - "Run Fit File Data Sync"
+      - "Run GPX File Data Sync"
+      - "Run TCX File Data Sync"
     types:
       - completed
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,9 +9,6 @@ on:
   workflow_run:
     workflows:
       - "Run Data Sync"
-      - "Run Fit File Data Sync"
-      - "Run GPX File Data Sync"
-      - "Run TCX File Data Sync"
     types:
       - completed
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,6 +3,9 @@ name: Publish GitHub Pages
 # Controls when the action will run.
 on:
   # trigger when the Run Data Sync workflow succeeded
+  push:
+    paths:
+      - src/**
   workflow_run:
     workflows:
       - "Run Data Sync"

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -1,27 +1,35 @@
 name: Run Data Sync
 
 on:
+  workflow_call:
+    inputs:
+      run_type:
+        required: true
+        type: string
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
-  push:
-    branches:
-      - master
-    paths:
-      - scripts/nike_sync.py
-      - scripts/nike_to_strava_sync.py
-      - scripts/strava_sync.py
-      - scripts/gen_svg.py
-      - scripts/garmin_sync.py
-      - scripts/keep_sync.py
-      - scripts/gpx_sync.py
-      - scripts/tcx_sync.py
-      - scripts/garmin_to_strava_sync.py
-      - requirements.txt
+    inputs:
+      logLevel:
+        description: 'run type'
+        required: true
+        default: 'pass'
+        type: choice
+        options:
+          - strava
+          - nike
+          - garmin
+          - garmin_cn
+          - keep
+          - only_gpx
+          - only_tcx
+          - only_fit
+          - nike_to_strava
+          - strava_to_garmin
+          - strava_to_garmin_cn
+          - garmin_to_strava
+          - garmin_to_strava_cn
+          - codoon
 
 env:
-  # please change to your own config.
-  RUN_TYPE: pass # support strava/nike/garmin/garmin_cn/keep/only_gpx/nike_to_strava/strava_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/codoon, Please change the 'pass' it to your own
   ATHLETE: yihong0618
   TITLE: Yihong0618 Running
   MIN_GRID_DISTANCE: 10 # change min distance here
@@ -67,78 +75,88 @@ jobs:
         if: steps.pip-cache.outputs.cache-hit != 'true'
 
       - name: Run sync Nike script
-        if: env.RUN_TYPE == 'nike'
+        if: inputs.run_type == 'nike'
         run: |
           python scripts/nike_sync.py ${{ secrets.NIKE_REFRESH_TOKEN }}
 
       - name: Run sync Nike to Strava(Run with nike data backup and show with strava)
-        if: env.RUN_TYPE == 'nike_to_strava'
+        if: inputs.run_type == 'nike_to_strava'
         run: |
           python scripts/nike_to_strava_sync.py ${{ secrets.NIKE_REFRESH_TOKEN }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}
 
       - name: Run sync Keep script
-        if: env.RUN_TYPE == 'keep'
+        if: inputs.run_type == 'keep'
         run: |
           python scripts/keep_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} --with-gpx
 
       - name: Run sync Strava script
-        if: env.RUN_TYPE == 'strava'
+        if: inputs.run_type == 'strava'
         run: |
           python scripts/strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}
         # python scripts/garmin_sync.py ${{ secrets.GARMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }} --only-run --is-cn
 
       - name: Run sync Codoon script
-        if: env.RUN_TYPE == 'codoon'
+        if: inputs.run_type == 'codoon'
         run: |
           python scripts/codoon_sync.py ${{ secrets.CODOON_MOBILE }} ${{ secrets.CODOON_PASSWORD }}
 
       # for garmin if you want generate `tcx` you can add --tcx command in the args.
       - name: Run sync Garmin script
-        if: env.RUN_TYPE == 'garmin'
+        if: inputs.run_type == 'garmin'
         run: |
           python scripts/garmin_sync.py ${{ secrets.GARMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }}
         # If you only want to sync `type running` add args --only-run, default script is to sync all data (rides and runs).
         # python scripts/garmin_sync.py ${{ secrets.GARMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }} --only-run
 
       - name: Run sync Garmin CN script
-        if: env.RUN_TYPE == 'garmin_cn'
+        if: inputs.run_type == 'garmin_cn'
         run: |
           python scripts/garmin_sync.py ${{ secrets.GARMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }} --is-cn
         # If you only want to sync `type running` add args --only-run, default script is to sync all data (rides and runs).
         # python scripts/garmin_sync.py ${{ secrets.GARMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }} --only-run --is-cn
 
       - name: Run sync Only GPX script
-        if: env.RUN_TYPE == 'only_gpx'
+        if: inputs.run_type == 'only_gpx'
         run: |
           python scripts/gpx_sync.py
 
+      - name: Run sync Only TCX script
+        if: inputs.run_type == 'only_tcx'
+        run: |
+          python scripts/tcx_sync.py
+
+      - name: Run sync Only FIT script
+        if: inputs.run_type == 'only_fit'
+        run: |
+          python scripts/fit_sync.py
+
       - name: Run sync Strava to Garmin(Run with strava(or others upload to strava) data backup in Garmin)
-        if: env.RUN_TYPE == 'strava_to_garmin'
+        if: inputs.run_type == 'strava_to_garmin'
         run: |
           python scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }} ${{ secrets.STRAVA_EMAIL }} ${{ secrets.STRAVA_PASSWORD }}
 
       - name: Run sync Strava to Garmin-cn(Run with strava(or others upload to strava) data backup in Garmin-cn)
-        if: env.RUN_TYPE == 'strava_to_garmin_cn'
+        if: inputs.run_type == 'strava_to_garmin_cn'
         run: |
           python scripts/strava_to_garmin_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }} ${{ secrets.STRAVA_EMAIL }} ${{ secrets.STRAVA_PASSWORD }} --is-cn
 
       - name: Run sync Garmin-cn to Strava(Run with Garmin data backup in Strava)
-        if: env.RUN_TYPE == 'garmin_to_strava_cn'
+        if: inputs.run_type == 'garmin_to_strava_cn'
         run: |
           python scripts/garmin_to_strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_CN_EMAIL }} ${{ secrets.GARMIN_CN_PASSWORD }} --is-cn
 
       - name: Run sync Garmin to Strava(Run with Garmin data backup in Strava)
-        if: env.RUN_TYPE == 'garmin_to_strava'
+        if: inputs.run_type == 'garmin_to_strava'
         run: |
           python scripts/garmin_to_strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }}
 
       - name: Run sync Tulipsport script
-        if: env.RUN_TYPE == 'tulipsport'
+        if: inputs.run_type == 'tulipsport'
         run: |
           python scripts/tulipsport_sync.py ${{ secrets.TULIPSPORT_TOKEN }} --with-gpx
 
       - name: Make svg GitHub profile
-        if: env.RUN_TYPE != 'pass'
+        if: inputs.run_type != 'pass'
         run: |
           python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
           python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set Variables
         id: set_variables
         run: |
-          sudo apt-get install libxml2-dev libxslt-dev python3-dev 
+          sudo apt-get install libxml2-dev libxslt-dev python3-dev
           echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
           echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
 
@@ -150,5 +150,5 @@ jobs:
           git config --local user.email "${{ env.GITHUB_EMAIL }}"
           git config --local user.name "${{ env.GITHUB_NAME }}"
           git add .
-          git commit -m 'update new runs' || echo "nothing to commit"
+          git commit -m '[skip ci] update new runs' || echo "nothing to commit"
           git push || echo "nothing to push"

--- a/.github/workflows/run_data_sync_on_schedule.yml
+++ b/.github/workflows/run_data_sync_on_schedule.yml
@@ -1,0 +1,14 @@
+name: Run Data Sync When Push
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  RUN_TYPE: pass #strava/nike/garmin/garmin_cn/keep/only_gpx/only_tcx/only_fit/nike_to_strava/strava_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/codoon
+
+jobs:
+  sync_fit_file:
+    uses: .github/workflows/run_data_sync.yml
+    with:
+      run_type: env.RUN_TYPE

--- a/.github/workflows/run_data_sync_when_push.yml
+++ b/.github/workflows/run_data_sync_when_push.yml
@@ -1,0 +1,27 @@
+name: Run Data Sync When Push
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - scripts/nike_sync.py
+      - scripts/nike_to_strava_sync.py
+      - scripts/strava_sync.py
+      - scripts/gen_svg.py
+      - scripts/garmin_sync.py
+      - scripts/keep_sync.py
+      - scripts/gpx_sync.py
+      - scripts/tcx_sync.py
+      - scripts/garmin_to_strava_sync.py
+      - requirements.txt
+
+env:
+  RUN_TYPE: pass
+
+jobs:
+  sync_fit_file:
+    if: false
+    uses: .github/workflows/run_data_sync.yml
+    with:
+      run_type: env.RUN_TYPE

--- a/.github/workflows/run_fit_sync_when_push_data.yml
+++ b/.github/workflows/run_fit_sync_when_push_data.yml
@@ -1,0 +1,77 @@
+name: Run Data Sync
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - scripts/FIT_sync.py
+      - FIT_OUT/**
+
+env:
+  # please change to your own config.
+  ENABLE: False
+  ATHLETE: yihong0618
+  TITLE: Yihong0618 Running
+  MIN_GRID_DISTANCE: 10 # change min distance here
+  TITLE_GRID: Over 10km Runs # also here
+  GITHUB_NAME: yihong0618 # change to yours
+  GITHUB_EMAIL: zouzou0208@gmail.com # change to yours
+
+  # IGNORE_BEFORE_SAVING: True # if you want to ignore some data before saving, set this to True
+  IGNORE_START_END_RANGE: 10 # Unit meter
+  # Dont making this huge, just picking points you needing. https://developers.google.com/maps/documentation/utilities/polylineutility using this tool to making your polyline
+  IGNORE_POLYLINE: "ktjrFoemeU~IorGq}DeB"
+  IGNORE_RANGE: 10 # Unit meter
+
+jobs:
+  sync:
+    if: env.ENABLE == True
+    name: Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      # from pdm and install dep
+      - name: Set Variables
+        id: set_variables
+        run: |
+          sudo apt-get install libxml2-dev libxslt-dev python3-dev
+          echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
+          echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache PIP
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.set_variables.outputs.PIP_CACHE }}
+          key: Ubuntu-pip-${{ steps.set_variables.outputs.PY }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+        if: steps.pip-cache.outputs.cache-hit != 'true'
+
+      - name: Run sync Only FIT script
+        run: |
+          python scripts/fit_sync.py
+
+      - name: Make svg GitHub profile
+        if: env.RUN_TYPE != 'pass'
+        run: |
+          python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
+          python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"
+          python scripts/gen_svg.py --from-db --type circular --use-localtime
+          python scripts/gen_svg.py --from-db --year $(date +"%Y")  --language zh_CN --title "$(date +"%Y") Running" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github_$(date +"%Y").svg --use-localtime --min-distance 0.5
+
+      - name: Push new runs
+        run: |
+          git config --local user.email "${{ env.GITHUB_EMAIL }}"
+          git config --local user.name "${{ env.GITHUB_NAME }}"
+          git add .
+          git commit -m '[skip ci] update new runs' || echo "nothing to commit"
+          git push || echo "nothing to push"

--- a/.github/workflows/run_fit_sync_when_push_data.yml
+++ b/.github/workflows/run_fit_sync_when_push_data.yml
@@ -9,68 +9,9 @@ on:
       - scripts/fit_sync.py
       - FIT_OUT/**
 
-env:
-  # please change to your own config.
-  ATHLETE: yihong0618
-  TITLE: Yihong0618 Running
-  MIN_GRID_DISTANCE: 10 # change min distance here
-  TITLE_GRID: Over 10km Runs # also here
-  GITHUB_NAME: yihong0618 # change to yours
-  GITHUB_EMAIL: zouzou0208@gmail.com # change to yours
-
-  # IGNORE_BEFORE_SAVING: True # if you want to ignore some data before saving, set this to True
-  IGNORE_START_END_RANGE: 10 # Unit meter
-  # Dont making this huge, just picking points you needing. https://developers.google.com/maps/documentation/utilities/polylineutility using this tool to making your polyline
-  IGNORE_POLYLINE: "ktjrFoemeU~IorGq}DeB"
-  IGNORE_RANGE: 10 # Unit meter
-
 jobs:
-  sync:
+  sync_fit_file:
     if: false
-    name: Sync
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
-      # from pdm and install dep
-      - name: Set Variables
-        id: set_variables
-        run: |
-          sudo apt-get install libxml2-dev libxslt-dev python3-dev
-          echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
-          echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache PIP
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.set_variables.outputs.PIP_CACHE }}
-          key: Ubuntu-pip-${{ steps.set_variables.outputs.PY }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        if: steps.pip-cache.outputs.cache-hit != 'true'
-
-      - name: Run sync Only FIT script
-        run: |
-          python scripts/fit_sync.py
-
-      - name: Make svg GitHub profile
-        run: |
-          python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
-          python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"
-          python scripts/gen_svg.py --from-db --type circular --use-localtime
-          python scripts/gen_svg.py --from-db --year $(date +"%Y")  --language zh_CN --title "$(date +"%Y") Running" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github_$(date +"%Y").svg --use-localtime --min-distance 0.5
-
-      - name: Push new runs
-        run: |
-          git config --local user.email "${{ env.GITHUB_EMAIL }}"
-          git config --local user.name "${{ env.GITHUB_NAME }}"
-          git add .
-          git commit -m '[skip ci] update new runs' || echo "nothing to commit"
-          git push || echo "nothing to push"
+    uses: .github/workflows/run_data_sync.yml
+    with:
+      run_type: only_fit

--- a/.github/workflows/run_fit_sync_when_push_data.yml
+++ b/.github/workflows/run_fit_sync_when_push_data.yml
@@ -1,16 +1,16 @@
-name: Run Data Sync
+name: Run Fit File Data Sync
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
     paths:
-      - scripts/FIT_sync.py
+      - scripts/fit_sync.py
       - FIT_OUT/**
 
 env:
   # please change to your own config.
-  ENABLE: False
   ATHLETE: yihong0618
   TITLE: Yihong0618 Running
   MIN_GRID_DISTANCE: 10 # change min distance here
@@ -26,7 +26,7 @@ env:
 
 jobs:
   sync:
-    if: env.ENABLE == True
+    if: false
     name: Sync
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +61,6 @@ jobs:
           python scripts/fit_sync.py
 
       - name: Make svg GitHub profile
-        if: env.RUN_TYPE != 'pass'
         run: |
           python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
           python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"

--- a/.github/workflows/run_gpx_sync_when_push_data.yml
+++ b/.github/workflows/run_gpx_sync_when_push_data.yml
@@ -1,0 +1,77 @@
+name: Run Data Sync
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - scripts/gpx_sync.py
+      - GPX_OUT/**
+
+env:
+  # please change to your own config.
+  ENABLE: False
+  ATHLETE: yihong0618
+  TITLE: Yihong0618 Running
+  MIN_GRID_DISTANCE: 10 # change min distance here
+  TITLE_GRID: Over 10km Runs # also here
+  GITHUB_NAME: yihong0618 # change to yours
+  GITHUB_EMAIL: zouzou0208@gmail.com # change to yours
+
+  # IGNORE_BEFORE_SAVING: True # if you want to ignore some data before saving, set this to True
+  IGNORE_START_END_RANGE: 10 # Unit meter
+  # Dont making this huge, just picking points you needing. https://developers.google.com/maps/documentation/utilities/polylineutility using this tool to making your polyline
+  IGNORE_POLYLINE: "ktjrFoemeU~IorGq}DeB"
+  IGNORE_RANGE: 10 # Unit meter
+
+jobs:
+  sync:
+    if: env.ENABLE == True
+    name: Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      # from pdm and install dep
+      - name: Set Variables
+        id: set_variables
+        run: |
+          sudo apt-get install libxml2-dev libxslt-dev python3-dev
+          echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
+          echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache PIP
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.set_variables.outputs.PIP_CACHE }}
+          key: Ubuntu-pip-${{ steps.set_variables.outputs.PY }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+        if: steps.pip-cache.outputs.cache-hit != 'true'
+
+      - name: Run sync Only GPX script
+        run: |
+          python scripts/gpx_sync.py
+
+      - name: Make svg GitHub profile
+        if: env.RUN_TYPE != 'pass'
+        run: |
+          python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
+          python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"
+          python scripts/gen_svg.py --from-db --type circular --use-localtime
+          python scripts/gen_svg.py --from-db --year $(date +"%Y")  --language zh_CN --title "$(date +"%Y") Running" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github_$(date +"%Y").svg --use-localtime --min-distance 0.5
+
+      - name: Push new runs
+        run: |
+          git config --local user.email "${{ env.GITHUB_EMAIL }}"
+          git config --local user.name "${{ env.GITHUB_NAME }}"
+          git add .
+          git commit -m '[skip ci] update new runs' || echo "nothing to commit"
+          git push || echo "nothing to push"

--- a/.github/workflows/run_gpx_sync_when_push_data.yml
+++ b/.github/workflows/run_gpx_sync_when_push_data.yml
@@ -1,6 +1,7 @@
-name: Run Data Sync
+name: Run GPX File Data Sync
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -10,7 +11,6 @@ on:
 
 env:
   # please change to your own config.
-  ENABLE: False
   ATHLETE: yihong0618
   TITLE: Yihong0618 Running
   MIN_GRID_DISTANCE: 10 # change min distance here
@@ -26,7 +26,7 @@ env:
 
 jobs:
   sync:
-    if: env.ENABLE == True
+    if: false
     name: Sync
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +61,6 @@ jobs:
           python scripts/gpx_sync.py
 
       - name: Make svg GitHub profile
-        if: env.RUN_TYPE != 'pass'
         run: |
           python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
           python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"

--- a/.github/workflows/run_gpx_sync_when_push_data.yml
+++ b/.github/workflows/run_gpx_sync_when_push_data.yml
@@ -9,68 +9,9 @@ on:
       - scripts/gpx_sync.py
       - GPX_OUT/**
 
-env:
-  # please change to your own config.
-  ATHLETE: yihong0618
-  TITLE: Yihong0618 Running
-  MIN_GRID_DISTANCE: 10 # change min distance here
-  TITLE_GRID: Over 10km Runs # also here
-  GITHUB_NAME: yihong0618 # change to yours
-  GITHUB_EMAIL: zouzou0208@gmail.com # change to yours
-
-  # IGNORE_BEFORE_SAVING: True # if you want to ignore some data before saving, set this to True
-  IGNORE_START_END_RANGE: 10 # Unit meter
-  # Dont making this huge, just picking points you needing. https://developers.google.com/maps/documentation/utilities/polylineutility using this tool to making your polyline
-  IGNORE_POLYLINE: "ktjrFoemeU~IorGq}DeB"
-  IGNORE_RANGE: 10 # Unit meter
-
 jobs:
-  sync:
+  sync_fit_file:
     if: false
-    name: Sync
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
-      # from pdm and install dep
-      - name: Set Variables
-        id: set_variables
-        run: |
-          sudo apt-get install libxml2-dev libxslt-dev python3-dev
-          echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
-          echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache PIP
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.set_variables.outputs.PIP_CACHE }}
-          key: Ubuntu-pip-${{ steps.set_variables.outputs.PY }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        if: steps.pip-cache.outputs.cache-hit != 'true'
-
-      - name: Run sync Only GPX script
-        run: |
-          python scripts/gpx_sync.py
-
-      - name: Make svg GitHub profile
-        run: |
-          python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
-          python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"
-          python scripts/gen_svg.py --from-db --type circular --use-localtime
-          python scripts/gen_svg.py --from-db --year $(date +"%Y")  --language zh_CN --title "$(date +"%Y") Running" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github_$(date +"%Y").svg --use-localtime --min-distance 0.5
-
-      - name: Push new runs
-        run: |
-          git config --local user.email "${{ env.GITHUB_EMAIL }}"
-          git config --local user.name "${{ env.GITHUB_NAME }}"
-          git add .
-          git commit -m '[skip ci] update new runs' || echo "nothing to commit"
-          git push || echo "nothing to push"
+    uses: .github/workflows/run_data_sync.yml
+    with:
+      run_type: only_gpx

--- a/.github/workflows/run_tcx_sync_when_push_data.yml
+++ b/.github/workflows/run_tcx_sync_when_push_data.yml
@@ -1,0 +1,77 @@
+name: Run Data Sync
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - scripts/tcx_sync.py
+      - TCX_OUT/**
+
+env:
+  # please change to your own config.
+  ENABLE: False
+  ATHLETE: yihong0618
+  TITLE: Yihong0618 Running
+  MIN_GRID_DISTANCE: 10 # change min distance here
+  TITLE_GRID: Over 10km Runs # also here
+  GITHUB_NAME: yihong0618 # change to yours
+  GITHUB_EMAIL: zouzou0208@gmail.com # change to yours
+
+  # IGNORE_BEFORE_SAVING: True # if you want to ignore some data before saving, set this to True
+  IGNORE_START_END_RANGE: 10 # Unit meter
+  # Dont making this huge, just picking points you needing. https://developers.google.com/maps/documentation/utilities/polylineutility using this tool to making your polyline
+  IGNORE_POLYLINE: "ktjrFoemeU~IorGq}DeB"
+  IGNORE_RANGE: 10 # Unit meter
+
+jobs:
+  sync:
+    if: env.ENABLE == True
+    name: Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      # from pdm and install dep
+      - name: Set Variables
+        id: set_variables
+        run: |
+          sudo apt-get install libxml2-dev libxslt-dev python3-dev
+          echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
+          echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache PIP
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.set_variables.outputs.PIP_CACHE }}
+          key: Ubuntu-pip-${{ steps.set_variables.outputs.PY }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+        if: steps.pip-cache.outputs.cache-hit != 'true'
+
+      - name: Run sync Only TCX script
+        run: |
+          python scripts/tcx_sync.py
+
+      - name: Make svg GitHub profile
+        if: env.RUN_TYPE != 'pass'
+        run: |
+          python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
+          python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"
+          python scripts/gen_svg.py --from-db --type circular --use-localtime
+          python scripts/gen_svg.py --from-db --year $(date +"%Y")  --language zh_CN --title "$(date +"%Y") Running" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github_$(date +"%Y").svg --use-localtime --min-distance 0.5
+
+      - name: Push new runs
+        run: |
+          git config --local user.email "${{ env.GITHUB_EMAIL }}"
+          git config --local user.name "${{ env.GITHUB_NAME }}"
+          git add .
+          git commit -m '[skip ci] update new runs' || echo "nothing to commit"
+          git push || echo "nothing to push"

--- a/.github/workflows/run_tcx_sync_when_push_data.yml
+++ b/.github/workflows/run_tcx_sync_when_push_data.yml
@@ -1,6 +1,7 @@
-name: Run Data Sync
+name: Run TCX File Data Sync
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -10,7 +11,6 @@ on:
 
 env:
   # please change to your own config.
-  ENABLE: False
   ATHLETE: yihong0618
   TITLE: Yihong0618 Running
   MIN_GRID_DISTANCE: 10 # change min distance here
@@ -26,7 +26,7 @@ env:
 
 jobs:
   sync:
-    if: env.ENABLE == True
+    if: false
     name: Sync
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +61,6 @@ jobs:
           python scripts/tcx_sync.py
 
       - name: Make svg GitHub profile
-        if: env.RUN_TYPE != 'pass'
         run: |
           python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
           python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"

--- a/.github/workflows/run_tcx_sync_when_push_data.yml
+++ b/.github/workflows/run_tcx_sync_when_push_data.yml
@@ -9,68 +9,9 @@ on:
       - scripts/tcx_sync.py
       - TCX_OUT/**
 
-env:
-  # please change to your own config.
-  ATHLETE: yihong0618
-  TITLE: Yihong0618 Running
-  MIN_GRID_DISTANCE: 10 # change min distance here
-  TITLE_GRID: Over 10km Runs # also here
-  GITHUB_NAME: yihong0618 # change to yours
-  GITHUB_EMAIL: zouzou0208@gmail.com # change to yours
-
-  # IGNORE_BEFORE_SAVING: True # if you want to ignore some data before saving, set this to True
-  IGNORE_START_END_RANGE: 10 # Unit meter
-  # Dont making this huge, just picking points you needing. https://developers.google.com/maps/documentation/utilities/polylineutility using this tool to making your polyline
-  IGNORE_POLYLINE: "ktjrFoemeU~IorGq}DeB"
-  IGNORE_RANGE: 10 # Unit meter
-
 jobs:
-  sync:
+  sync_fit_file:
     if: false
-    name: Sync
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
-      # from pdm and install dep
-      - name: Set Variables
-        id: set_variables
-        run: |
-          sudo apt-get install libxml2-dev libxslt-dev python3-dev
-          echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
-          echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache PIP
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.set_variables.outputs.PIP_CACHE }}
-          key: Ubuntu-pip-${{ steps.set_variables.outputs.PY }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        if: steps.pip-cache.outputs.cache-hit != 'true'
-
-      - name: Run sync Only TCX script
-        run: |
-          python scripts/tcx_sync.py
-
-      - name: Make svg GitHub profile
-        run: |
-          python scripts/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
-          python scripts/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"
-          python scripts/gen_svg.py --from-db --type circular --use-localtime
-          python scripts/gen_svg.py --from-db --year $(date +"%Y")  --language zh_CN --title "$(date +"%Y") Running" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github_$(date +"%Y").svg --use-localtime --min-distance 0.5
-
-      - name: Push new runs
-        run: |
-          git config --local user.email "${{ env.GITHUB_EMAIL }}"
-          git config --local user.name "${{ env.GITHUB_NAME }}"
-          git add .
-          git commit -m '[skip ci] update new runs' || echo "nothing to commit"
-          git push || echo "nothing to push"
+    uses: .github/workflows/run_data_sync.yml
+    with:
+      run_type: only_tcx

--- a/scripts/garmin_sync.py
+++ b/scripts/garmin_sync.py
@@ -386,6 +386,12 @@ if __name__ == "__main__":
         help="if is only for running",
     )
     parser.add_argument(
+        "--only-download",
+        dest="only_download",
+        action="store_true",
+        help="if is only for download personal documents",
+    )
+    parser.add_argument(
         "--tcx",
         dest="download_file_type",
         action="store_const",
@@ -409,6 +415,7 @@ if __name__ == "__main__":
     )
     file_type = options.download_file_type
     is_only_running = options.only_run
+    is_only_download = options.only_download
     if email == None or password == None:
         print("Missing argument nor valid configuration file")
         sys.exit(1)
@@ -431,4 +438,5 @@ if __name__ == "__main__":
         )
     )
     loop.run_until_complete(future)
-    make_activities_file(SQL_FILE, folder, JSON_FILE, file_suffix=file_type)
+    if not is_only_download:
+        make_activities_file(SQL_FILE, folder, JSON_FILE, file_suffix=file_type)


### PR DESCRIPTION
1. `FIT_OUT`,`GPX_OUT`,`TCX_OUT`三个文件夹添加数据文件后，添加了三个action，出发相应的sync脚本。

2. CI中的提交commit message前都加上了`[skip ci]`，可以表明CI抓取数据后的push导致出发上面的action。

3. garmin_sync添加了`--only-doowload`参数。可以只下载数据。