### PR TITLE
fix: 同一天有多个运动时选中地图路线显示错误问题

### DIFF
--- a/scripts/gpxtrackposter/grid_drawer.py
+++ b/scripts/gpxtrackposter/grid_drawer.py
@@ -74,5 +74,5 @@ class GridDrawer(TracksDrawer):
                 stroke_linejoin="round",
                 stroke_linecap="round",
             )
-            polyline.set_desc(title=date_title)
+            polyline.set_desc(title=date_title, desc=tr.run_id)
             dr.add(polyline)

--- a/scripts/gpxtrackposter/track.py
+++ b/scripts/gpxtrackposter/track.py
@@ -114,6 +114,7 @@ class Track:
             summary_polyline = filter_out(activity.summary_polyline)
         polyline_data = polyline.decode(summary_polyline) if summary_polyline else []
         self.polylines = [[s2.LatLng.from_degrees(p[0], p[1]) for p in polyline_data]]
+        self.run_id = activity.run_id
 
     def bbox(self):
         """Compute the smallest rectangle that contains the entire track (border box)."""

--- a/src/components/RunTable/RunRow.jsx
+++ b/src/components/RunTable/RunRow.jsx
@@ -11,7 +11,7 @@ const RunRow = ({ elementIndex, locateActivity, run, runIndex, setRunIndex }) =>
   const handleClick = (e) => {
     if (runIndex === elementIndex) return;
     setRunIndex(elementIndex);
-    locateActivity(run.start_date_local.slice(0, 10));
+    locateActivity([run.run_id]);
   };
 
   return (


### PR DESCRIPTION
如果同一天有多条运动记录时，从列表、路线缩略图及日期方块选择纪录，地图会显示错误的路线。
具体讨论可以查看：
[https://github.com/ben-29/workouts_page/issues/17](https://github.com/ben-29/workouts_page/issues/17)
[https://github.com/ben-29/workouts_page/pull/18](https://github.com/ben-29/workouts_page/pull/18)