### PR TITLE
#484 导出keep接口升级无法获取gpx数据的跑步记录

### DIFF
--- a/run_page/keep_sync.py
+++ b/run_page/keep_sync.py
@@ -85,23 +85,26 @@ def parse_raw_data_to_nametuple(
     ):
         raw_data_url = run_data.get("rawDataURL")
         r = session.get(raw_data_url)
-        # string strart with `H4sIAAAAAAAA` --> decode and unzip
-        run_points_data = decode_runmap_data(r.text)
-        run_points_data_gpx = run_points_data
-        if TRANS_GCJ02_TO_WGS84:
-            run_points_data = [
-                list(eviltransform.gcj2wgs(p["latitude"], p["longitude"]))
-                for p in run_points_data
-            ]
-            for i, p in enumerate(run_points_data_gpx):
-                p["latitude"] = run_points_data[i][0]
-                p["longitude"] = run_points_data[i][1]
+        if r.status_code == 200:
+            # string strart with `H4sIAAAAAAAA` --> decode and unzip
+            run_points_data = decode_runmap_data(r.text)
+            run_points_data_gpx = run_points_data
+            if TRANS_GCJ02_TO_WGS84:
+                run_points_data = [
+                    list(eviltransform.gcj2wgs(p["latitude"], p["longitude"]))
+                    for p in run_points_data
+                ]
+                for i, p in enumerate(run_points_data_gpx):
+                    p["latitude"] = run_points_data[i][0]
+                    p["longitude"] = run_points_data[i][1]
+            else:
+                run_points_data = [[p["latitude"], p["longitude"]] for p in run_points_data]
+            if with_download_gpx:
+                if str(keep_id) not in old_gpx_ids:
+                    gpx_data = parse_points_to_gpx(run_points_data_gpx, start_time)
+                    download_keep_gpx(gpx_data, str(keep_id))
         else:
-            run_points_data = [[p["latitude"], p["longitude"]] for p in run_points_data]
-        if with_download_gpx:
-            if str(keep_id) not in old_gpx_ids:
-                gpx_data = parse_points_to_gpx(run_points_data_gpx, start_time)
-                download_keep_gpx(gpx_data, str(keep_id))
+            print(f"ID {keep_id} retrieved gpx data failed")
     heart_rate = None
     if run_data["heartRate"]:
         heart_rate = run_data["heartRate"].get("averageHeartRate", None)

--- a/run_page/keep_sync.py
+++ b/run_page/keep_sync.py
@@ -98,7 +98,9 @@ def parse_raw_data_to_nametuple(
                     p["latitude"] = run_points_data[i][0]
                     p["longitude"] = run_points_data[i][1]
             else:
-                run_points_data = [[p["latitude"], p["longitude"]] for p in run_points_data]
+                run_points_data = [
+                    [p["latitude"], p["longitude"]] for p in run_points_data
+                ]
             if with_download_gpx:
                 if str(keep_id) not in old_gpx_ids:
                     gpx_data = parse_points_to_gpx(run_points_data_gpx, start_time)

--- a/run_page/keep_sync.py
+++ b/run_page/keep_sync.py
@@ -85,7 +85,7 @@ def parse_raw_data_to_nametuple(
     ):
         raw_data_url = run_data.get("rawDataURL")
         r = session.get(raw_data_url)
-        if r.status_code == 200:
+        if r.ok:
             # string strart with `H4sIAAAAAAAA` --> decode and unzip
             run_points_data = decode_runmap_data(r.text)
             run_points_data_gpx = run_points_data


### PR DESCRIPTION

# 导出keep接口升级无法获取gpx数据的跑步记录

之前对于没有成功获取到gpx的跑步记录会抛出异常，导致该跑步记录导出失败；

现在不再抛出异常，保证跑步记录可以被导出，不过导出的跑步记录没有gpx。
