### PR TITLE
feat: reduce grid svg file size

### DIFF
--- a/run_page/gpxtrackposter/utils.py
+++ b/run_page/gpxtrackposter/utils.py
@@ -58,9 +58,13 @@ def project(
     scale = size.x / d_x if size.x / size.y <= d_x / d_y else size.y / d_y
     offset = offset + 0.5 * (size - scale * XY(d_x, -d_y)) - scale * XY(min_x, min_y)
     lines = []
+    # If len > $zoom_threshold, choose 1 point out of every $step to reduce size of the SVG file
+    zoom_threshold = 400
     for latlngline in latlnglines:
         line = []
-        for latlng in latlngline:
+        step = int(len(latlngline) / zoom_threshold) + 1
+        for i in range(0, len(latlngline), step):
+            latlng = latlngline[i]
             if bbox.contains(latlng):
                 line.append((offset + scale * latlng2xy(latlng)).tuple())
             else:


### PR DESCRIPTION
When rendering the grid.svg, it will display all polylines in the `grid.svg`. However, a route can be quite large. For example, a marathon may contain thousands of data points, which is just one running record. Nevertheless, the polyline in the SVG does not need to be overly precise.

I have added a `zoom_threshold` to control whether to omit some data points when the length is too long. This threshold ensures that the length of each polyline remains below the specified value.
In my case, before this change, my grid.svg was 10.9MB and after reducing it became 3.6MB.
Increase this parameter if you want fewer affected polylines. Decrease it if you want a smaller SVG file.

Note: This change primarily affects track running because it drops data points between circles. Therefore, data points during turns may be discarded resulting in less smooth lines or sharp turns.

![image](https://github.com/yihong0618/running_page/assets/6956444/b5c720c8-ecca-4699-8057-d60b565ad15c)





