### PR TITLE
fix: gh-pages build: drop the ref while trigger from Run Data Sync

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: Cache Data Files
         if: inputs.save_data_in_github_cache

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -48,6 +48,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
         with:
+          # if your default branches is not master, please change it here
           ref: master
 
       - name: Cache Data Files


### PR DESCRIPTION
When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event.
If build GitHub page from Run Data Sync,  it may be outdated. And user needs to run the action again to build from the latest commit.
![image](https://github.com/yihong0618/running_page/assets/6956444/eb00272a-7d84-4c83-969c-7a62f6081292)
see: https://github.com/actions/checkout#usage

