### PR TITLE
Update strava_to_garmin_sync.py

### DIFF
--- a/run_page/strava_to_garmin_sync.py
+++ b/run_page/strava_to_garmin_sync.py
@@ -92,7 +92,7 @@ async def upload_to_activities(
         return files_list
 
     # strava rate limit
-    for i in strava_activities[: len(strava_activities)]:
+    for i in sorted(strava_activities, key=lambda i: int(i.id)):
         try:
             data = strava_web_client.get_activity_data(i.id, fmt=format)
             files_list.append(data)


### PR DESCRIPTION
Sort the activities downloaded from Strava by their id's thus they are uploaded to Garmin from the oldest to the latest. Otherwise, the latest one is uploaded first, and if the process is interrupted, any activities older than it will never be uploaded because the code before this line gets the latest activity from Garmin and only download those newer than it from Strava.