### PR TITLE
perf: split `activities.json` from index

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,14 @@ export default defineConfig({
   build: {
     manifest: true,
     outDir: './dist', // for user easy to use, vercel use default dir -> dist
+    rollupOptions: {
+      output: {
+        manualChunks: (id: string) => {
+          if (id.includes('activities')) {
+            return 'activities'
+          }
+        },
+      }
+    },
   },
 });


### PR DESCRIPTION
Splitting activities.json from index-xxx.js to improve the initial loading experience.

The left side of the image is the split part.
![split-chunks](https://github.com/yihong0618/running_page/assets/85230052/5fb21d1a-0acf-4231-abe1-dd172287eb5b)
