### PR TITLE
fix: total state SVG

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,6 +48,9 @@ const Index = () => {
     func: (_run: Activity, _value: string) => boolean
   ) => {
     scrollToMap();
+    if(name != 'Year'){
+      setYear(thisYear)
+    }
     setActivity(filterAndSortRuns(activities, item, func, sortDateFunc));
     setRunIndex(-1);
     setTitle(`${item} ${name} Running Heatmap`);


### PR DESCRIPTION
update the year when change by Title & City, otherwise the `SVG` will be displayed and the table will not be shown if the previous status is 'Total'

![image](https://github.com/yihong0618/running_page/assets/6956444/5509aeb7-27d2-41fe-b009-629004cd829d)
