### PR TITLE
fix: Codoon tcx output use start_time as ID instead of Codoon id

### DIFF
--- a/run_page/codoon_sync.py
+++ b/run_page/codoon_sync.py
@@ -160,7 +160,7 @@ def tcx_output(fit_array, run_data):
     activities.append(activity)
     #   Id
     activity_id = ET.Element("Id")
-    activity_id.text = fit_start_time # Codoon use start_time as ID
+    activity_id.text = fit_start_time  # Codoon use start_time as ID
     activity.append(activity_id)
     #   Creator
     activity_creator = ET.Element("Creator")

--- a/run_page/codoon_sync.py
+++ b/run_page/codoon_sync.py
@@ -129,6 +129,12 @@ def formated_input(
 def tcx_output(fit_array, run_data):
     # route ID
     fit_id = str(run_data["id"])
+    # local time
+    fit_start_time_local = run_data["start_time"]
+    # zulu time
+    utc = adjust_time_to_utc(to_date(fit_start_time_local), str(get_localzone()))
+    fit_start_time = utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+
     # Root node
     training_center_database = ET.Element(
         "TrainingCenterDatabase",
@@ -154,7 +160,7 @@ def tcx_output(fit_array, run_data):
     activities.append(activity)
     #   Id
     activity_id = ET.Element("Id")
-    activity_id.text = fit_id
+    activity_id.text = fit_start_time # Codoon use start_time as ID
     activity.append(activity_id)
     #   Creator
     activity_creator = ET.Element("Creator")
@@ -164,13 +170,6 @@ def tcx_output(fit_array, run_data):
     activity_creator_name.text = "咕咚"
     activity_creator.append(activity_creator_name)
     #   Lap
-
-    # local time
-    fit_start_time_local = run_data["start_time"]
-    # zulu time
-    utc = adjust_time_to_utc(to_date(fit_start_time_local), str(get_localzone()))
-    fit_start_time = utc.strftime("%Y-%m-%dT%H:%M:%SZ")
-
     activity_lap = ET.Element("Lap", {"StartTime": fit_start_time})
     activity.append(activity_lap)
     #       TotalTimeSeconds

--- a/run_page/utils.py
+++ b/run_page/utils.py
@@ -40,7 +40,7 @@ def to_date(ts):
             # shouldn't be an issue since it's an offline cmdline tool
             return datetime.strptime(ts, ts_fmt)
         except ValueError:
-            print("Error: Can not execute strptime")
+            print(f"Warning: Can not execute strptime {ts} with ts_fmt {ts_fmt}, try next one...")
             pass
 
     raise ValueError(f"cannot parse timestamp {ts} into date with fmts: {ts_fmts}")

--- a/run_page/utils.py
+++ b/run_page/utils.py
@@ -40,7 +40,9 @@ def to_date(ts):
             # shouldn't be an issue since it's an offline cmdline tool
             return datetime.strptime(ts, ts_fmt)
         except ValueError:
-            print(f"Warning: Can not execute strptime {ts} with ts_fmt {ts_fmt}, try next one...")
+            print(
+                f"Warning: Can not execute strptime {ts} with ts_fmt {ts_fmt}, try next one..."
+            )
             pass
 
     raise ValueError(f"cannot parse timestamp {ts} into date with fmts: {ts_fmts}")


### PR DESCRIPTION
fix #508 