### PR TITLE
Feat: lights switch

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -232,6 +232,8 @@ siteMetadata: {
 const USE_DASH_LINE = true;
 // styling: 透明度：[0, 1]
 const LINE_OPACITY = 0.4;
+// styling: 默认关灯: 设置为 `false`, 仅在隐私模式关闭时生效(`PRIVACY_MODE` = false)
+const DEFAULT_LIGHTS_ON = true;
 ```
 
 > 隐私保护：设置下面环境变量：

--- a/README-CN.md
+++ b/README-CN.md
@@ -232,8 +232,10 @@ siteMetadata: {
 const USE_DASH_LINE = true;
 // styling: 透明度：[0, 1]
 const LINE_OPACITY = 0.4;
+// styling: 开启隐私模式(不显示地图仅显示轨迹): 设置为 `true`
+const PRIVACY_MODE = false;
 // styling: 默认关灯: 设置为 `false`, 仅在隐私模式关闭时生效(`PRIVACY_MODE` = false)
-const DEFAULT_LIGHTS_ON = true;
+const LIGHTS_ON = true;
 ```
 
 > 隐私保护：设置下面环境变量：

--- a/README.md
+++ b/README.md
@@ -215,8 +215,10 @@ siteMetadata: {
 const USE_DASH_LINE = true;
 // styling: route line opacity: [0, 1]
 const LINE_OPACITY = 0.4;
+// styling: set to `true` if you want to display only the routes without showing the map.
+const PRIVACY_MODE = false;
 // styling: set to `false` if you want to make light off as default, only effect when `PRIVACY_MODE` = false
-const DEFAULT_LIGHTS_ON = true;
+const LIGHTS_ON = true;
 ```
 
 - To use Google Analytics, you need to modify the configuration in the `src/utils/const.ts` file.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ siteMetadata: {
 const USE_DASH_LINE = true;
 // styling: route line opacity: [0, 1]
 const LINE_OPACITY = 0.4;
+// styling: set to `false` if you want to make light off as default, only effect when `PRIVACY_MODE` = false
+const DEFAULT_LIGHTS_ON = true;
 ```
 
 - To use Google Analytics, you need to modify the configuration in the `src/utils/const.ts` file.

--- a/src/components/RunMap/LightsControl.tsx
+++ b/src/components/RunMap/LightsControl.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from './style.module.scss';
+
+interface ILightsProps {
+  setLights: (_lights: boolean) => void;
+  lights: boolean;
+}
+
+const LightsControl = ({ setLights, lights }: ILightsProps) => {
+
+  return (
+        <div className={"mapboxgl-ctrl mapboxgl-ctrl-group  " + styles.lights}>
+          <button className={`${lights? styles.lightsOn : styles.lightsOff}`} onClick={() => setLights(!lights)}>
+            <span className="mapboxgl-ctrl-icon" aria-hidden="true"
+                  title={"Turn " + `${lights ? 'off' : 'on'}` + " the Light"}></span>
+          </button>
+        </div>
+  );
+};
+
+export default LightsControl;

--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -82,9 +82,16 @@ const RunMap = ({
   // for geojson format
   filterProvinces.unshift('in', 'name');
 
+  const initGeoDataLength = geoData.features.length;
   const isBigMap = (viewState.zoom ?? 0) <= 3;
   if (isBigMap && IS_CHINESE) {
-    geoData = geoJsonForMap();
+    // Show boundary and line together, combine geoData(only when not combine yet)
+    if(geoData.features.length === initGeoDataLength){
+      geoData = {
+          "type": "FeatureCollection",
+          "features": geoData.features.concat(geoJsonForMap().features)
+      };
+    }
   }
 
   const isSingleRun =

--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -106,7 +106,7 @@ const RunMap = ({
     [startLon, startLat] = points[0];
     [endLon, endLat] = points[points.length - 1];
   }
-  let dash = USE_DASH_LINE && !isSingleRun ? [2, 2] : [2, 0];
+  let dash = USE_DASH_LINE && !isSingleRun && !isBigMap ? [2, 2] : [2, 0];
   const onMove = React.useCallback(({ viewState }: {viewState: IViewState}) => {
     setViewState(viewState);
   }, []);
@@ -145,9 +145,9 @@ const RunMap = ({
           type="line"
           paint={{
             'line-color': MAIN_COLOR,
-            'line-width': isBigMap ? 1 : 2,
+            'line-width': isBigMap && lights ? 1 : 2,
             'line-dasharray': dash,
-            'line-opacity': isSingleRun ? 1 : LINE_OPACITY,
+            'line-opacity': isSingleRun || isBigMap || !lights ? 1 : LINE_OPACITY,
             'line-blur': 1,
           }}
           layout={{

--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -42,6 +42,20 @@ const RunMap = ({
   const { provinces } = useActivities();
   const mapRef = useRef<MapRef>();
   const [lights, setLights] = useState(true);
+  const [lights, setLights] = useState(LIGHTS_ON);
+  const keepWhenLightsOff = ['runs2']
+  function switchLayerVisibility(map: MapInstance, lights: boolean) {
+    const styleJson = map.getStyle();
+    styleJson.layers.forEach(it => {
+        if (!keepWhenLightsOff.includes(it.id)) {
+          if (lights)
+            map.setLayoutProperty(it.id, 'visibility', 'visible');
+          else
+            map.setLayoutProperty(it.id, 'visibility', 'none');
+        }
+      }
+    )
+  }
   const mapRefCallback = useCallback(
     (ref: MapRef) => {
       if (ref !== null) {
@@ -49,30 +63,21 @@ const RunMap = ({
         if (map && IS_CHINESE) {
             map.addControl(new MapboxLanguage({defaultLanguage: 'zh-Hans'}));
         }
-        map.on('load', () => {
+        // all style resources have been downloaded
+        // and the first visually complete rendering of the base style has occurred.
+        map.on('style.load', () => {
             if (!ROAD_LABEL_DISPLAY) {
               MAP_LAYER_LIST.forEach((layerId) => {
                 map.removeLayer(layerId);
               });
             }
             mapRef.current = ref;
+            switchLayerVisibility(map, lights);
         });
       }
       if (mapRef.current) {
         const map = mapRef.current.getMap();
-        if (map) {
-          const styleJson = map.getStyle();
-          const keepWhenLightsOff = ['runs2']
-          styleJson.layers.forEach(it => {
-              if (!keepWhenLightsOff.includes(it.id)) {
-                if (lights)
-                  map.setLayoutProperty(it.id, 'visibility', 'visible');
-                else
-                  map.setLayoutProperty(it.id, 'visibility', 'none');
-              }
-            }
-          )
-        }
+        switchLayerVisibility(map, lights);
       }
     },
     [mapRef, lights]

--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -1,6 +1,7 @@
 import MapboxLanguage from '@mapbox/mapbox-gl-language';
 import React, {useRef, useCallback, useState} from 'react';
 import Map, {Layer, Source, FullscreenControl, NavigationControl, MapRef} from 'react-map-gl';
+import {MapInstance} from "react-map-gl/src/types/lib";
 import useActivities from '@/hooks/useActivities';
 import {
   MAP_LAYER_LIST,
@@ -12,6 +13,8 @@ import {
   USE_DASH_LINE,
   LINE_OPACITY,
   MAP_HEIGHT,
+  PRIVACY_MODE,
+  LIGHTS_ON,
 } from '@/utils/const';
 import { Coordinate, IViewState, geoJsonForMap } from '@/utils/utils';
 import RunMarker from './RunMarker';
@@ -41,20 +44,18 @@ const RunMap = ({
 }: IRunMapProps) => {
   const { provinces } = useActivities();
   const mapRef = useRef<MapRef>();
-  const [lights, setLights] = useState(true);
-  const [lights, setLights] = useState(LIGHTS_ON);
+  const [lights, setLights] = useState(PRIVACY_MODE ? false : LIGHTS_ON);
   const keepWhenLightsOff = ['runs2']
   function switchLayerVisibility(map: MapInstance, lights: boolean) {
     const styleJson = map.getStyle();
     styleJson.layers.forEach(it => {
-        if (!keepWhenLightsOff.includes(it.id)) {
-          if (lights)
-            map.setLayoutProperty(it.id, 'visibility', 'visible');
-          else
-            map.setLayoutProperty(it.id, 'visibility', 'none');
-        }
+      if (!keepWhenLightsOff.includes(it.id)) {
+        if (lights)
+          map.setLayoutProperty(it.id, 'visibility', 'visible');
+        else
+          map.setLayoutProperty(it.id, 'visibility', 'none');
       }
-    )
+    })
   }
   const mapRefCallback = useCallback(
     (ref: MapRef) => {
@@ -66,13 +67,13 @@ const RunMap = ({
         // all style resources have been downloaded
         // and the first visually complete rendering of the base style has occurred.
         map.on('style.load', () => {
-            if (!ROAD_LABEL_DISPLAY) {
-              MAP_LAYER_LIST.forEach((layerId) => {
-                map.removeLayer(layerId);
-              });
-            }
-            mapRef.current = ref;
-            switchLayerVisibility(map, lights);
+          if (!ROAD_LABEL_DISPLAY) {
+            MAP_LAYER_LIST.forEach((layerId) => {
+              map.removeLayer(layerId);
+            });
+          }
+          mapRef.current = ref;
+          switchLayerVisibility(map, lights);
         });
       }
       if (mapRef.current) {
@@ -170,7 +171,7 @@ const RunMap = ({
       )}
       <span className={styles.runTitle}>{title}</span>
       <FullscreenControl style={fullscreenButton}/>
-      <LightsControl setLights={setLights} lights={lights}/>
+      {!PRIVACY_MODE && <LightsControl setLights={setLights} lights={lights}/>}
       <NavigationControl showCompass={false} position={'bottom-right'} style={{opacity: 0.3}}/>
     </Map>
   );

--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -51,7 +51,6 @@ const RunMap = ({
         }
         map.on('load', () => {
             if (!ROAD_LABEL_DISPLAY) {
-              // todo delete layers
               MAP_LAYER_LIST.forEach((layerId) => {
                 map.removeLayer(layerId);
               });
@@ -117,7 +116,7 @@ const RunMap = ({
   const fullscreenButton: React.CSSProperties = {
     position: 'absolute',
     marginTop: '29.2px',
-    right: '10px',
+    right: '0px',
     opacity: 0.3,
   };
 

--- a/src/components/RunMap/style.module.scss
+++ b/src/components/RunMap/style.module.scss
@@ -45,7 +45,7 @@
 .lights {
   position: absolute;
   margin-top: 62px;
-  right: 20px;
+  right: 10px;
   opacity: 0.3;
   width: 29px;
   height: 38px;

--- a/src/components/RunMap/style.module.scss
+++ b/src/components/RunMap/style.module.scss
@@ -41,3 +41,31 @@
   font-family: $global-font-family;
   cursor: pointer;
 }
+
+.lights {
+  position: absolute;
+  margin-top: 62px;
+  right: 20px;
+  opacity: 0.3;
+  width: 29px;
+  height: 38px;
+}
+
+
+.lightsOn {
+  height: 38px !important;
+  background-image: url("data:image/svg+xml,<svg xmlns='http%3A//www.w3.org/2000/svg' height='32px' viewBox='0 0 384 512'><style>svg%7Bfill%3A%23000000%7D<%2Fstyle><path d='M297.2 248.9C311.6 228.3 320 203.2 320 176c0-70.7-57.3-128-128-128S64 105.3 64 176c0 27.2 8.4 52.3 22.8 72.9c3.7 5.3 8.1 11.3 12.8 17.7l0 0c12.9 17.7 28.3 38.9 39.8 59.8c10.4 19 15.7 38.8 18.3 57.5H109c-2.2-12-5.9-23.7-11.8-34.5c-9.9-18-22.2-34.9-34.5-51.8l0 0 0 0c-5.2-7.1-10.4-14.2-15.4-21.4C27.6 247.9 16 213.3 16 176C16 78.8 94.8 0 192 0s176 78.8 176 176c0 37.3-11.6 71.9-31.4 100.3c-5 7.2-10.2 14.3-15.4 21.4l0 0 0 0c-12.3 16.8-24.6 33.7-34.5 51.8c-5.9 10.8-9.6 22.5-11.8 34.5H226.4c2.6-18.7 7.9-38.6 18.3-57.5c11.5-20.9 26.9-42.1 39.8-59.8l0 0 0 0 0 0c4.7-6.4 9-12.4 12.7-17.7zM192 128c-26.5 0-48 21.5-48 48c0 8.8-7.2 16-16 16s-16-7.2-16-16c0-44.2 35.8-80 80-80c8.8 0 16 7.2 16 16s-7.2 16-16 16zm0 384c-44.2 0-80-35.8-80-80V416H272v16c0 44.2-35.8 80-80 80z'/><%2Fsvg>");
+  margin-bottom: auto;
+  background-repeat: no-repeat;
+  background-position: center center;
+  opacity: 1;
+}
+
+.lightsOff {
+  height: 38px !important;
+  background-image: url("data:image/svg+xml,<svg xmlns='http%3A//www.w3.org/2000/svg' height='32px' viewBox='0 0 384 512'><style>svg%7Bfill%3A%23000000%7D<%2Fstyle><path d='M272 384c9.6-31.9 29.5-59.1 49.2-86.2l0 0c5.2-7.1 10.4-14.2 15.4-21.4c19.8-28.5 31.4-63 31.4-100.3C368 78.8 289.2 0 192 0S16 78.8 16 176c0 37.3 11.6 71.9 31.4 100.3c5 7.2 10.2 14.3 15.4 21.4l0 0c19.8 27.1 39.7 54.4 49.2 86.2H272zM192 512c44.2 0 80-35.8 80-80V416H112v16c0 44.2 35.8 80 80 80zM112 176c0 8.8-7.2 16-16 16s-16-7.2-16-16c0-61.9 50.1-112 112-112c8.8 0 16 7.2 16 16s-7.2 16-16 16c-44.2 0-80 35.8-80 80z'/><%2Fsvg>");
+  margin-bottom: auto;
+  background-repeat: no-repeat;
+  background-position: center center;
+  opacity: 1;
+}

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -35,6 +35,8 @@ const LINE_OPACITY = 0.4;
 const MAP_HEIGHT = 600;
 //set to `false` if you want to hide the road label characters
 const ROAD_LABEL_DISPLAY = true;
+//set to `true` if you want to display only the routes without showing the map.
+const PRIVACY_MODE = true;
 //set to `false` if you want to make light off as default, only effect when `PRIVACY_MODE` = false
 const LIGHTS_ON = true;
 
@@ -88,6 +90,7 @@ export {
   USE_DASH_LINE,
   LINE_OPACITY,
   MAP_HEIGHT,
+  PRIVACY_MODE,
   LIGHTS_ON,
 };
 

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -36,7 +36,7 @@ const MAP_HEIGHT = 600;
 //set to `false` if you want to hide the road label characters
 const ROAD_LABEL_DISPLAY = true;
 //set to `true` if you want to display only the routes without showing the map.
-const PRIVACY_MODE = true;
+const PRIVACY_MODE = false;
 //set to `false` if you want to make light off as default, only effect when `PRIVACY_MODE` = false
 const LIGHTS_ON = true;
 

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -35,6 +35,8 @@ const LINE_OPACITY = 0.4;
 const MAP_HEIGHT = 600;
 //set to `false` if you want to hide the road label characters
 const ROAD_LABEL_DISPLAY = true;
+//set to `false` if you want to make light off as default, only effect when `PRIVACY_MODE` = false
+const LIGHTS_ON = true;
 
 // IF you outside China please make sure IS_CHINESE = false
 const IS_CHINESE = true;
@@ -86,6 +88,7 @@ export {
   USE_DASH_LINE,
   LINE_OPACITY,
   MAP_HEIGHT,
+  LIGHTS_ON,
 };
 
 const nike = 'rgb(224,237,94)'; // if you want change the main color change here src/styles/variables.scss


### PR DESCRIPTION
Add a light switch button, when turned off, displays only the routes and blacks out the entire map. These features come with some other changes.
1. In the Easter Egg map, display both the China boundary and the running routes, not just the China boundary.
2. In lights-off mode, turn off dash lines and line transparency, and enhance the line to emphasize the route.
