### PR TITLE
fix: svg not found causes page crash

### DIFF
--- a/src/components/SVGStat/index.tsx
+++ b/src/components/SVGStat/index.tsx
@@ -1,27 +1,12 @@
-import { ComponentType, lazy, Suspense } from 'react'
+import { lazy, Suspense } from 'react'
 import styles from './style.module.scss';
 import { totalStat } from '@assets/index'
+import { loadSvgComponent } from '@/utils/svgUtils';
 
 // Lazy load both github.svg and grid.svg
-const GithubSvg = lazy(() =>
-  totalStat['./github.svg']()
-    .then((res) => {
-      return { default: res as ComponentType<any> }
-    })
-    .catch(() => {
-      return { default: () => <div>Failed to load SVG</div> };
-    })
-)
+const GithubSvg = lazy(() => loadSvgComponent(totalStat, './github.svg'))
 
-const GridSvg = lazy(() =>
-  totalStat['./grid.svg']()
-    .then((res) => {
-      return { default: res as ComponentType<any> }
-    })
-    .catch(() => {
-      return { default: () => <div>Failed to load SVG</div> };
-    })
-)
+const GridSvg = lazy(() => loadSvgComponent(totalStat, './grid.svg'))
 
 const SVGStat = () => (
   <div id="svgStat">

--- a/src/components/YearStat/index.tsx
+++ b/src/components/YearStat/index.tsx
@@ -1,24 +1,18 @@
-import { ComponentType, lazy, Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 import Stat from '@/components/Stat';
 import useActivities from '@/hooks/useActivities';
 import { formatPace } from '@/utils/utils';
 import styles from './style.module.scss';
 import useHover from '@/hooks/useHover';
-import { yearStats } from '@assets/index'
+import { yearStats } from '@assets/index';
+import { loadSvgComponent } from '@/utils/svgUtils';
 
 const YearStat = ({ year, onClick }: { year: string, onClick: (_year: string) => void }) => {
   let { activities: runs, years } = useActivities();
   // for hover
   const [hovered, eventHandlers] = useHover();
   // lazy Component
-  const YearSVG = lazy(() =>
-    yearStats[`./year_${year}.svg`]()
-      .then((res) => ({ default: res as ComponentType<any> }))
-      .catch((err) => {
-        console.error(err);
-        return { default: () => <div>Failed to load SVG</div> };
-      })
-  );
+  const YearSVG = lazy(() => loadSvgComponent(yearStats, `./year_${year}.svg`));
 
   if (years.includes(year)) {
     runs = runs.filter((run) => run.start_date_local.slice(0, 4) === year);

--- a/src/utils/svgUtils.tsx
+++ b/src/utils/svgUtils.tsx
@@ -1,0 +1,20 @@
+import { ComponentType } from 'react';
+
+type SvgComponent = {
+  default: ComponentType<any>;
+};
+
+const FailedLoadSvg = () => <div>Failed to load SVG</div>;
+
+export const loadSvgComponent = async (
+  stats: Record<string, () => Promise<unknown>>,
+  path: string
+): Promise<SvgComponent> => {
+  try {
+    const module = await stats[path]();
+    return { default: module as ComponentType<any> };
+  } catch (error) {
+    console.error(error);
+    return { default: FailedLoadSvg };
+  }
+};


### PR DESCRIPTION
Before

When hovering over the `YearStat` component, the page crashes if the `./year_${year}.svg` file is not found.

<details>
<summary>Error call stack</summary>
TypeError: yearStats[year] is not a function
    at http://localhost:5173/src/components/YearStat/index.tsx?t=1705334672175:30:42
    at lazyInitializer (http://localhost:5173/node_modules/.vite/deps/chunk-5HQCJSLF.js?v=dfc8bfd7:869:28)
    at mountLazyComponent (http://localhost:5173/node_modules/.vite/deps/chunk-S3R3ZQRI.js?v=dfc8bfd7:14817:27)
    at beginWork (http://localhost:5173/node_modules/.vite/deps/chunk-S3R3ZQRI.js?v=dfc8bfd7:15906:22)
    at beginWork$1 (http://localhost:5173/node_modules/.vite/deps/chunk-S3R3ZQRI.js?v=dfc8bfd7:19749:22)
    at performUnitOfWork (http://localhost:5173/node_modules/.vite/deps/chunk-S3R3ZQRI.js?v=dfc8bfd7:19194:20)
    at workLoopSync (http://localhost:5173/node_modules/.vite/deps/chunk-S3R3ZQRI.js?v=dfc8bfd7:19133:13)
    at renderRootSync (http://localhost:5173/node_modules/.vite/deps/chunk-S3R3ZQRI.js?v=dfc8bfd7:19112:15)
    at recoverFromConcurrentError (http://localhost:5173/node_modules/.vite/deps/chunk-S3R3ZQRI.js?v=dfc8bfd7:18732:28)
    at performConcurrentWorkOnRoot (http://localhost:5173/node_modules/.vite/deps/chunk-S3R3ZQRI.js?v=dfc8bfd7:18680:30)
</details>

https://github.com/yihong0618/running_page/assets/85230052/5f5ba533-314b-47d6-82c0-4e3311618006

After

https://github.com/yihong0618/running_page/assets/85230052/12cd0730-86e4-4048-949e-1f7a5824e502

