### PR TITLE
Update actions version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         id: setup_python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'


### PR DESCRIPTION
[The recent GitHub Actions](https://github.com/yihong0618/running_page/actions/runs/7722942807) shows deprecation annotation saying they have changed [Node.js 16 to 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.)

The ci.yml file is updated In this PR:
- Upgrade checkout to v4 from v3
- Upgrade setup-python from v4 to v5