### PR TITLE
Update GitHub Actions and README

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,14 +46,14 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # if your default branches is not master, please change it here
           ref: master
 
       - name: Cache Data Files
         if: inputs.save_data_in_github_cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             activities
@@ -71,9 +71,9 @@ jobs:
             ${{ inputs.data_cache_prefix }}-
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm
@@ -86,7 +86,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -100,10 +100,10 @@ jobs:
         run: PATH_PREFIX=/${{ github.event.repository.name }} pnpm build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           # Upload dist repository
           path: './dist'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -49,11 +49,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         id: setup_python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: pip
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache Data Files
         if: env.SAVE_DATA_IN_GITHUB_CACHE == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             activities

--- a/README-CN.md
+++ b/README-CN.md
@@ -96,7 +96,8 @@ R.I.P. 希望大家都能健康顺利的跑过终点，逝者安息。
 | [Jeffggmm](https://github.com/Jeffggmm)           | <https://jeffggmm.github.io/workouts_page/>    | Garmin      |
 | [s1smart](https://github.com/s1smart)             | <https://s1smart.github.io/running_page/>      | Strava      |
 | [Ryan](https://github.com/85Ryan)                 | <https://85ryan.github.io/gooorun/>            | Strava      |
-| [PPZ](https://github.com/8824PPZ)                 | <https://run.dudubbbbbbbbb.top/>            | Strava      |
+| [PPZ](https://github.com/8824PPZ)                 | <https://run.dudubbbbbbbbb.top/>               | Strava      |
+| [Yer1k](https://github.com/Yer1k)                 | <https://running.yer1k.com/>                   | Strava      |
 </details>
 
 ## 它是怎么工作的
@@ -956,11 +957,11 @@ python3(python) run_page/gen_svg.py --from-db --type circular --use-localtime
 4. 为 GitHub Actions 添加代码提交权限，访问仓库的 `Settings > Actions > General`页面，找到 `Workflow permissions` 的设置项，将选项配置为 `Read and write permissions`，支持 CI 将运动数据更新后提交到仓库中。
 
 
-5. 如果想把你的 running_page 部署在 xxx.github.io 而不是 xxx.github.io/run_page，需要做三点
+5. 如果想把你的 running_page 部署在 xxx.github.io 而不是 xxx.github.io/run_page 亦或是想要添加自定义域名于 GitHub Pages，需要做三点
 
 -  修改你的 fork 的 running_page 仓库改名为 xxx.github.io, xxx 是你 github 的 username
 -  修改 gh-pages.yml 中的 Build 模块，删除 `${{ github.event.repository.name }}` 改为`run: PATH_PREFIX=/ pnpm build` 即可
--  src/static/site-metadata.ts 中 `siteUrl: ''` 即可
+-  修改 src/static/site-metadata.ts 中 `siteUrl: ''` 或是添加你的自定义域名，`siteUrl: '[your_own_domain]'`， 即可
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ English | [简体中文](https://github.com/yihong0618/running_page/blob/master/
 | [XmchxUp](https://github.com/XmchxUp)             | <https://xmchxup.github.io/running_page/>      | Strava      |
 | [Ryan](https://github.com/85Ryan)                 | <https://85ryan.github.io/gooorun/>            | Strava      |
 | [PPZ](https://github.com/8824PPZ)                 | <https://run.dudubbbbbbbbb.top/>               | Strava      |
-| [Yer1k](https://github.com/Yer1k)                 | <https://yer1k.github.io/running_page/>        | Strava      |
+| [Yer1k](https://github.com/Yer1k)                 | <https://running.yer1k.com/>                   | Strava      |
 </details>
 
 ## How it works
@@ -776,11 +776,11 @@ For more display effects, see:
 
 4. make sure you have write permissions in Workflow permissions settings.
 
-5. If you want to deploy your running_page to xxx.github.io instead of xxx.github.io/running_page, you need to do three things:
+5. If you want to deploy your running_page to xxx.github.io instead of xxx.github.io/running_page or redirect your GitHub Pages to a custom domain, you need to do three things:
 
 - Rename your forked running_page repository to `xxx.github.io`, where xxx is your GitHub username
 - Modify the Build module in gh-pages.yml, remove `${{ github.event.repository.name }}` and change to `run: PATH_PREFIX=/ pnpm build`
-- In `src/static/site-metadata.ts`, set siteUrl: ''
+- In `src/static/site-metadata.ts`, set siteUrl: '' or your custom domain URL
 
 </details>
 


### PR DESCRIPTION
In this PR, the following items are updated:

1. Updated .github/workflows/gh-pages.yml:

   - actions/checkout from v3 to v4
   - actions/cache from v3 to v4
   - actions/setup-node from v3 to v4 with node-version from 18 to 20
   - actions/upload-pages-artifact from v1 to v2
      - Note: v3 and v4 are incompatible with actions/upload-artifact@v3, [which currently do not support on GHES](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new)  
   - actions/deploy-pages from v1 to v3

1. Updated .github/workflows/run_data_sync.yml:

   - actions/checkout from v3 to v4
   - actions/setup-python from v4 to v5
   - actions/cache from v3 to v4

1. Updated README:

   - Updated Yer1k's running page link
   - Added instructions for people who would like to deploy their running page on GitHub.io with custom domain to avoid potential artifact index issues

> PS: I have tested the changes on my own repo, and they all worked as expected; however we would still get annotations/warnings on GitHub Actions due to "Node.js 16 actions are deprecated", which is caused by pnpm/action-setup@v2 and actions/upload-artifact@v3. As for the former, other people have started [PRs](https://github.com/pnpm/action-setup/pulls) on that project, trying to fix the Node issue, yet it has not been updated. Then for the latter one, as mentioned in list 1, even though the Node issue has been fixed, due to GHES incompatibility, we currently cannot update the upload-artifact version. Please feel free to let me know if anything needs to be changed before the merge. Cheers! 