### PR TITLE
feat: coros sync

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -1,7 +1,7 @@
 name: Run Data Sync
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
   push:
@@ -13,6 +13,7 @@ on:
       - run_page/strava_sync.py
       - run_page/gen_svg.py
       - run_page/garmin_sync.py
+      - run_page/coros.py
       - run_page/keep_sync.py
       - run_page/gpx_sync.py
       - run_page/tcx_sync.py
@@ -21,7 +22,7 @@ on:
 
 env:
   # please change to your own config.
-  RUN_TYPE: pass # support strava/nike/garmin/garmin_cn/garmin_sync_cn_global/keep/only_gpx/only_fit/nike_to_strava/strava_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/codoon, Please change the 'pass' it to your own
+  RUN_TYPE: pass # support strava/nike/garmin/coros/garmin_cn/garmin_sync_cn_global/keep/only_gpx/only_fit/nike_to_strava/strava_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/codoon, Please change the 'pass' it to your own
   ATHLETE: yihong0618
   TITLE: Yihong0618 Running
   MIN_GRID_DISTANCE: 10 # change min distance here
@@ -97,6 +98,11 @@ jobs:
         run: |
           python run_page/keep_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} --with-gpx
 
+      - name: Run sync Coros script
+        if: env.RUN_TYPE == 'coros'
+        run: |
+          python run_page/coros_sync.py ${{ secrets.COROS_ACCOUNT }} ${{ secrets.COROS_PASSWORD }}
+
       - name: Run sync Strava script
         if: env.RUN_TYPE == 'strava'
         run: |
@@ -133,7 +139,7 @@ jobs:
         # If you only want to sync `type running` add args --only-run, default script is to sync all data (rides and runs).
         # python run_page/garmin_sync_cn_global.py ${{ secrets.GARMIN_SECRET_STRING_CN }} ${{ secrets.GARMIN_SECRET_STRING }}  --only-run
 
-      
+
       - name: Run sync Only GPX script
         if: env.RUN_TYPE == 'only_gpx'
         run: |

--- a/README-CN.md
+++ b/README-CN.md
@@ -129,6 +129,7 @@ R.I.P. 希望大家都能健康顺利的跑过终点，逝者安息。
 
 - **[Strava](#strava)**
 - **[Nike Run Club](#nike-run-club)**
+- **[Coros高驰](#coros高驰)**
 - **[Garmin](#garmin)**
 - **[Garmin-cn](#garmin-cn-大陆用户请用这个)**
 - **[Keep](#keep)**
@@ -499,6 +500,24 @@ python3(python) run_page/tulipsport_sync.py nLgy****RyahI
 ```
 
 </details>
+
+### Coros高驰
+
+<details>
+<summary>获取您的 Coros高驰 数据</summary>
+
+#### 获取加密后的密码
+
+  - 登录高驰后台进行登录， 登录前打开控制台，获取加密后的密码，以便后续获取数据使用
+  - ![corog_login.png](https://img3.uploadhouse.com/fileuploads/30980/30980073e464362e6eaa8f1988ac2e3124cd8a46.png)
+#### 设置 github action中Coros高驰信息
+  - 在github action中配置`COROS_ACCOUNT`,`COROS_PASSWORD`参数，密码为上图中的`<pwd>`
+
+在终端中输入以下命令
+```bash
+python run_page/coros_sync.py ${{ secrets.COROS_ACCOUNT }} ${{ secrets.COROS_PASSWORD }}
+```
+
 
 ### Garmin
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ English | [简体中文](https://github.com/yihong0618/running_page/blob/master/
 - **[GPX](#gpx)**
 - **[TCX](#tcx)**
 - **[FIT](#fit)**
+- **[Coros](#Coros)**
 - **[Garmin-CN_to_Garmin(Sync Garmin-CN activities to Garmin Global)](#garmin-cn-to-garmin)**
 - **[Nike_to_Strava(Using NRC Run, Strava backup data)](#nike_to_strava)**
 - **[Tcx_to_Strava(upload all tcx data to strava)](#tcx_to_strava)**
@@ -297,6 +298,27 @@ python3(python) run_page/fit_sync.py
 ```
 
 </details>
+
+### Coros
+
+<details>
+<summary>Get your Coros data</summary>
+
+#### Gets the encrypted password
+
+  - https://t.coros.com/login， Before logging on, open the developer console and get the encrypted password for subsequent data access
+  - ![corog_login.png](https://img3.uploadhouse.com/fileuploads/30980/30980073e464362e6eaa8f1988ac2e3124cd8a46.png)
+#### Set the Coros account information in github action
+  - configure the `COROS_ACCOUNT` , `COROS_PASSWORD` parameter in github action with the password '<pwd> ' as shown above
+
+Enter the following command in the terminal
+
+```bash
+python run_page/coros_sync.py 'your coros account' 'pwd obtained from console'
+```
+</details>
+
+
 
 ### Garmin
 

--- a/run_page/coros_sync.py
+++ b/run_page/coros_sync.py
@@ -1,0 +1,144 @@
+import argparse
+import asyncio
+import logging
+import os
+
+import aiohttp
+
+from config import JSON_FILE, SQL_FILE, FIT_FOLDER
+from utils import make_activities_file
+
+logger = logging.getLogger(__name__)
+
+COROS_URL_DICT = {
+    "LOGIN_URL": "https://teamcnapi.coros.com/account/login",
+    "ACTIVITY_URL": "https://connectapi.garmin.cn/activity-service/activity/{activity_id}",
+    "DOWNLOAD_URL": "https://teamcnapi.coros.com/activity/detail/download",
+}
+
+
+class Coros:
+    def __init__(self, headers, access_token):
+        headers.update(
+            {
+                "accesstoken": access_token,
+                "cookie": f"CPL-coros-region=2; CPL-coros-token={access_token}",
+            }
+        )
+
+        self.headers = headers
+        self.upload_url = COROS_URL_DICT.get("UPLOAD_URL")
+        self.activity_url = COROS_URL_DICT.get("ACTIVITY_URL")
+        self.login_url = COROS_URL_DICT.get("LOGIN_URL")
+
+    @staticmethod
+    async def login(account, password):
+        url = COROS_URL_DICT.get("LOGIN_URL")
+        headers = {
+            "authority": "teamcnapi.coros.com",
+            "accept": "application/json, text/plain, */*",
+            "accept-language": "zh-CN,zh;q=0.9",
+            "content-type": "application/json;charset=UTF-8",
+            "dnt": "1",
+            "origin": "https://t.coros.com",
+            "referer": "https://t.coros.com/",
+            "sec-ch-ua": '"Chromium";v="122", "Not(A:Brand";v="24", "Google Chrome";v="122"',
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"macOS"',
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "same-site",
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+        }
+        data = {"account": account, "accountType": 2, "pwd": password}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=data, headers=headers) as response:
+                resp_json = await response.json()
+                access_token = resp_json["data"]["accessToken"]
+                return Coros(headers, access_token)
+
+    async def fetch_activity_ids(self, session):
+        page_number = 1
+        all_activities_ids = []
+
+        while True:
+            url = f"https://teamcnapi.coros.com/activity/query?size=20&pageNumber={page_number}&modeList=100,102,103"
+            headers = self.headers
+
+            async with session.get(url, headers=headers) as response:
+                data = await response.json()
+                logger.debug("activity data:", data)
+                activities = data.get("data", {}).get("dataList", None)
+                if not activities:
+                    break  # 如果当前页面没有活动，结束循环
+                for activity in activities:
+                    label_id = activity["labelId"]
+                    all_activities_ids.append(label_id)
+
+                page_number += 1  # 准备获取下一个页面的数据
+
+        return all_activities_ids
+
+    async def download_activity(self, session, label_id):
+        download_folder = FIT_FOLDER
+        download_url = f"{COROS_URL_DICT.get('DOWNLOAD_URL')}?labelId={label_id}&sportType=100&fileType=4"
+        headers = self.headers
+        async with session.post(download_url, headers=headers) as response:
+            resp_json = await response.json()
+            file_url = resp_json["data"]["fileUrl"]
+            fname = os.path.basename(file_url)
+            async with session.get(file_url) as res:
+                if res.status == 200:
+                    file_path = os.path.join(download_folder, fname)
+                    with open(file_path, "wb") as f:
+                        while True:
+                            chunk = await res.content.read(4096)
+                            if not chunk:
+                                break
+                            f.write(chunk)
+                    return label_id, fname
+        return None, None
+
+
+def get_downloaded_ids(folder):
+    return [i.split(".")[0] for i in os.listdir(folder) if not i.startswith(".")]
+
+
+async def download_and_generate(account, password):
+    folder = FIT_FOLDER
+    downloaded_ids = get_downloaded_ids(folder)
+    client = await Coros.login(account, password)
+
+    async with aiohttp.ClientSession() as session:
+        activity_ids = await client.fetch_activity_ids(session)
+        #  目前个别的 label id 和下载的id可能不一致 导致每次都会下载新的
+        print("activity_ids:", len(activity_ids))
+        print("downloaded_ids:", len(downloaded_ids))
+        # diff downloaded label id,
+        to_generate_coros_ids = list(set(activity_ids) - set(downloaded_ids))
+        print("to_generate_activity_ids: ", len(to_generate_coros_ids))
+        tasks = []
+        for label_id in to_generate_coros_ids:
+            task = client.download_activity(session, label_id)
+            tasks.append(task)
+        # 等待所有下载任务完成
+        await asyncio.gather(*tasks)
+        # 处理图片
+        make_activities_file(SQL_FILE, FIT_FOLDER, JSON_FILE, "fit")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "account", nargs="?", help="account is your coros email account"
+    )
+
+    parser.add_argument(
+        "password", nargs="?", help="password is your coros secret password"
+    )
+    options = parser.parse_args()
+
+    account = options.account
+    password = options.password
+
+    asyncio.run(download_and_generate(account, password))


### PR DESCRIPTION
去年把手表从 garmin 切换到高驰， 在没有 strava 前一直用手动同步给Garmin再生成running_page 😅， 
后面结合 strava 发现目前的功能已经完全支持我的需求
coros -> strava -> running_page
coros -> strava_to_garmin -> running_page  备份数据
不过最近刚好在学python，结合ChatGPT，照猫画虎写了高驰的数据同步 😀
