### PR TITLE
chore: Update package manager and ignore requirements-dev.txt

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,1 +1,2 @@
 requirements.txt  
+requirements-dev.txt  

--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
     "prettier": "2.8.8",
     "typescript": "^5.1.6"
   },
-  "packageManager": "pnpm@8.7.0"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Fix issue vercel error: spawn pip3 ENOENT by:
- Update packageManager field from "pnpm@8.7.0" to "yarn@1.22.22"
- Add `requirements-dev.txt` to `.vercelignore`

close: #627

<img width="1221" alt="image" src="https://github.com/yihong0618/running_page/assets/15976103/50224b68-31dd-43fa-96f4-429d904b1a79">


@ben-29 can you help to review, maybe workouts_page also need this