### PR TITLE
Add proxy config, add keep config, change npm registry, use yarn

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -185,6 +185,9 @@ docker build -t running_page:latest . --build-arg app=Strava --build-arg client_
 #Nike_to_Strava
 docker build -t running_page:latest . --build-arg app=Nike_to_Strava  --build-arg nike_refresh_token="" --build-arg client_id=""  --build-arg client_secret=""  --build-arg refresh_token=""
 
+# Keep
+docker build -t running_page:latest . --build-arg app=Keep --build-arg keep_phone_number="" --build-arg keep_password=""
+
 #启动
 docker run -itd -p 80:80   running_page:latest
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ docker build -t running_page:latest . --build-arg app=Strava --build-arg client_
 # Nike_to_Strava
 docker build -t running_page:latest . --build-arg app=Nike_to_Strava  --build-arg nike_refresh_token="" --build-arg client_id=""  --build-arg client_secret=""  --build-arg refresh_token=""
 
+# Keep
+docker build -t running_page:latest . --build-arg app=Keep --build-arg keep_phone_number="" --build-arg keep_password=""
+
 # run
 docker run -itd -p 80:80   running_page:latest
 


### PR DESCRIPTION
1. https://registry.npm.taobao.org has been expired, use https://registry.npmjs.org/.
2. add proxy config for someone who needed.
3. Use yarn instead of pnpm(Has some fault when build docker).
4. Add Keep config.