### PR TITLE
add keep2strava

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -104,6 +104,13 @@ jobs:
         run: |
           python run_page/coros_sync.py ${{ secrets.COROS_ACCOUNT }} ${{ secrets.COROS_PASSWORD }}
 
+      - name: Run sync Keep_to_strava script
+        if: env.RUN_TYPE == 'keep_to_strava'
+        run: |
+          python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
+        # If you only want to sync `type running` modify args --sync-types running, default script is to sync all data (rides, hikes and runs).
+        # If you only want to sync data from keep to strava, and the running page display the data from strava, you need to change the "if: env.RUN_TYPE == 'keep_to_strava'" -> "if: env.RUN_TYPE == 'strava'"
+        
       - name: Run sync Strava script
         if: env.RUN_TYPE == 'strava'
         run: |

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -109,8 +109,7 @@ jobs:
         run: |
           python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
         # If you only want to sync `type running` modify args --sync-types running, default script is to sync all data (rides, hikes and runs).
-        # If you only want to sync data from keep to strava, and the running page display the data from strava, you need to change the "if: env.RUN_TYPE == 'keep_to_strava_sync'" -> "if: env.RUN_TYPE == 'strava'"
-        
+
       - name: Run sync Strava script
         if: env.RUN_TYPE == 'strava'
         run: |

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -105,7 +105,7 @@ jobs:
           python run_page/coros_sync.py ${{ secrets.COROS_ACCOUNT }} ${{ secrets.COROS_PASSWORD }}
 
       - name: Run sync Keep_to_strava script
-        if: env.RUN_TYPE == 'keep_to_strava'
+        if: env.RUN_TYPE == 'keep_to_strava_sync'
         run: |
           python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
         # If you only want to sync `type running` modify args --sync-types running, default script is to sync all data (rides, hikes and runs).

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -18,6 +18,7 @@ on:
       - run_page/gpx_sync.py
       - run_page/tcx_sync.py
       - run_page/garmin_to_strava_sync.py
+      - run_page/keep_to_strava_sync.py
       - requirements.txt
 
 env:

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
         # If you only want to sync `type running` modify args --sync-types running, default script is to sync all data (rides, hikes and runs).
-        # If you only want to sync data from keep to strava, and the running page display the data from strava, you need to change the "if: env.RUN_TYPE == 'keep_to_strava'" -> "if: env.RUN_TYPE == 'strava'"
+        # If you only want to sync data from keep to strava, and the running page display the data from strava, you need to change the "if: env.RUN_TYPE == 'keep_to_strava_sync'" -> "if: env.RUN_TYPE == 'strava'"
         
       - name: Run sync Strava script
         if: env.RUN_TYPE == 'strava'

--- a/README-CN.md
+++ b/README-CN.md
@@ -921,32 +921,14 @@ python3(python) run_page/keep_to_strava_sync.py ${your mobile} ${your password} 
     - 华为运动健康: 户外跑步，户外骑行，户外步行。
 
 #### 特性以及使用细节:
-1. 与Keep相似，但是由keep_to_strava_sync.py实现，不侵入data.db 与 activities.json。因此不会出现由于同时使用keep_sync和strava_sync而导致的数据重复统计/展示问题。当然，也因为不侵入db和activities，导致该方法也无法独立的用于将数据统计/展示在网页上(想要展示需要和Strava配合)。
+1. 与Keep相似，但是由keep_to_strava_sync.py实现，不侵入data.db 与 activities.json。因此不会出现由于同时使用keep_sync和strava_sync而导致的数据重复统计/展示问题。
 2. 上传至Strava时，会自动识别为Strava中相应的运动类型, 目前支持的运动类型为running, cycling, hiking。
-3. 针对不同的需求主要有两种使用方法：
-    3.1 如果使用该项目仅仅只是为了将华为运动健康/OPPO健康等数据同步到Strava，那么只在run_data_sync.yml中将RUN_TYPE修改为
+3. run_data_sync.yml中的修改：
 
     ```yaml
-    RUN_TYPE: keep_to_starva
+    RUN_TYPE: keep_to_starva_sync
     ```
 
-    3.2 如果使用该项目是为了展示自己的running page，而且使用的设备/APP是华为/OPPO等可以链接到Keep的设备，打算将数据统一到Strava中，并在running page上展示的用户，那么需要在/.github/workflows/run_data_sync.yml中进行两步修改
-    - RUN_TYPE改为
-        ```yaml
-        RUN_TYPE: starva
-        ```
-    - if: env.RUN_TYPE == 'keep_to_strava'改为
-        ```yaml
-        if: env.RUN_TYPE == 'strava'
-        ```
-        示例：
-
-        ```yaml
-            - name: Run sync Keep_to_strava script
-                if: env.RUN_TYPE == 'strava'
-                run: |
-                    python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
-        ```
 </details>
 
 ### Total Data Analysis

--- a/README-CN.md
+++ b/README-CN.md
@@ -333,7 +333,7 @@ python3(python) run_page/keep_sync.py ${your mobile} ${your password}
 python3(python) run_page/keep_sync.py 13333xxxx example
 ```
 
-> 我增加了 keep 可以导出 gpx 功能（因 keep 的原因，距离和速度会有一定缺失）, 执行如下命令，导出的 gpx 会加入到 GPX_OUT 中，方便上传到其它软件
+> 我增加了 keep 可以导出 gpx 功能（因 keep 的原因，距离和速度会有一定缺失）, 执行如下命令，导出的 gpx 会加入到 GPX_OUT 中，方便上传到其它软件。
 
 ```bash
 python3(python) run_page/keep_sync.py ${your mobile} ${your password} --with-gpx
@@ -342,8 +342,21 @@ python3(python) run_page/keep_sync.py ${your mobile} ${your password} --with-gpx
 示例：
 
 ```bash
-python3(python) run_page/keep_sync.py 13333xxxx example --with-gpx
+python3(python) run_page/keep_sync.py 13333xxxx example --with-gpx 
 ```
+
+> 增加了 keep 对其他运动类型的支持，目前可选的有running, cycling, hiking，默认的运动数据类型为running。
+
+```bash
+python3(python) run_page/keep_sync.py ${your mobile} ${your password} --with-gpx --sync-types running cycling hiking
+```
+
+示例：
+
+```bash
+python3(python) run_page/keep_sync.py 13333xxxx example --with-gpx --sync-types running cycling hiking
+```
+
 
 </details>
 
@@ -891,6 +904,41 @@ python run_page/coros_sync.py ${{ secrets.COROS_ACCOUNT }} ${{ secrets.COROS_PAS
   ![github-action](https://img3.uploadhouse.com/fileuploads/30980/3098042335f8995623f8b50776c4fad4cf7fff8d.png)
 
 </details>
+
+### Keep_to_Strava
+<details>
+<summary>获取您的Keep数据，然后同步到Strava</summary>
+
+示例:
+```bash
+python3(python) run_page/keep_to_strava_sync.py ${your mobile} ${your password} ${client_id} ${client_secret} ${strava_refresh_token} --sync-types running cycling hiking
+```
+
+特性:
+1. 与Keep相似，但是由keep_to_strava_sync.py实现，不侵入data.db 与 activities.json(不会出现数据展示重复的问题)。
+2. 上传至Strava时，会自动识别为Strava中相应的运动类型, 目前支持的运动类型为running, cycling, hiking。
+3. 适用于由Strava总览/展示数据，但是数据来自不同设备的用户(有此需求的用户可以不用再执行keep_sync.py)。针对此需求，需要在run_data_sync.yml中strava的位置增加一句
+
+```yaml
+python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
+```
+
+示例：
+
+```yaml
+      - name: Run sync Strava script
+        if: env.RUN_TYPE == 'strava'
+        run: |
+        python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
+        python run_page/strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}
+
+```
+
+
+4. 理论上华为/OPPO等可以通过APP同步到Keep的设备，均可通过此方法自动同步到Strava，目前已通过测试的APP有
+    - 华为运动健康: 户外跑步，户外骑行，户外步行。
+
+
 
 ### Total Data Analysis
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -914,31 +914,40 @@ python run_page/coros_sync.py ${{ secrets.COROS_ACCOUNT }} ${{ secrets.COROS_PAS
 python3(python) run_page/keep_to_strava_sync.py ${your mobile} ${your password} ${client_id} ${client_secret} ${strava_refresh_token} --sync-types running cycling hiking
 ```
 
-特性:
-1. 与Keep相似，但是由keep_to_strava_sync.py实现，不侵入data.db 与 activities.json(不会出现数据展示重复的问题)。
-2. 上传至Strava时，会自动识别为Strava中相应的运动类型, 目前支持的运动类型为running, cycling, hiking。
-3. 适用于由Strava总览/展示数据，但是数据来自不同设备的用户(有此需求的用户可以不用再执行keep_sync.py)。针对此需求，需要在run_data_sync.yml中strava的位置增加一句
-
-```yaml
-python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
-```
-
-示例：
-
-```yaml
-      - name: Run sync Strava script
-        if: env.RUN_TYPE == 'strava'
-        run: |
-        python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
-        python run_page/strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}
-
-```
-
-
-4. 理论上华为/OPPO等可以通过APP同步到Keep的设备，均可通过此方法自动同步到Strava，目前已通过测试的APP有
+#### 解决的需求：
+1. 适用于由Strava总览/展示数据，但是有多种运动类型，且数据来自不同设备的用户。
+2. 适用于期望将华为运动健康/OPPO健康等数据同步到Strava的用户(前提是手机APP端已经开启了和Keep之间的数据同步)。
+3. 理论上华为/OPPO等可以通过APP同步到Keep的设备，均可通过此方法自动同步到Strava，目前已通过测试的APP有
     - 华为运动健康: 户外跑步，户外骑行，户外步行。
 
+#### 特性以及使用细节:
+1. 与Keep相似，但是由keep_to_strava_sync.py实现，不侵入data.db 与 activities.json。因此不会出现由于同时使用keep_sync和strava_sync而导致的数据重复统计/展示问题。当然，也因为不侵入db和activities，导致该方法也无法独立的用于将数据统计/展示在网页上(想要展示需要和Strava配合)。
+2. 上传至Strava时，会自动识别为Strava中相应的运动类型, 目前支持的运动类型为running, cycling, hiking。
+3. 针对不同的需求主要有两种使用方法：
+    3.1 如果使用该项目仅仅只是为了将华为运动健康/OPPO健康等数据同步到Strava，那么只在run_data_sync.yml中将RUN_TYPE修改为
 
+    ```yaml
+    RUN_TYPE: keep_to_starva
+    ```
+
+    3.2 如果使用该项目是为了展示自己的running page，而且使用的设备/APP是华为/OPPO等可以链接到Keep的设备，打算将数据统一到Strava中，并在running page上展示的用户，那么需要在/.github/workflows/run_data_sync.yml中进行两步修改
+    - RUN_TYPE改为
+        ```yaml
+        RUN_TYPE: starva
+        ```
+    - if: env.RUN_TYPE == 'keep_to_strava'改为
+        ```yaml
+        if: env.RUN_TYPE == 'strava'
+        ```
+        示例：
+
+        ```yaml
+            - name: Run sync Keep_to_strava script
+                if: env.RUN_TYPE == 'strava'
+                run: |
+                    python run_page/keep_to_strava_sync.py ${{ secrets.KEEP_MOBILE }} ${{ secrets.KEEP_PASSWORD }} ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }} --sync-types running cycling hiking
+        ```
+</details>
 
 ### Total Data Analysis
 

--- a/run_page/keep_sync.py
+++ b/run_page/keep_sync.py
@@ -135,7 +135,9 @@ def parse_raw_data_to_nametuple(
             if p_hr:
                 p["hr"] = p_hr
         if with_download_gpx:
-            if str(keep_id) not in old_gpx_ids and run_data["dataType"].startswith("outdoor"):
+            if str(keep_id) not in old_gpx_ids and run_data["dataType"].startswith(
+                "outdoor"
+            ):
                 gpx_data = parse_points_to_gpx(
                     run_points_data_gpx, start_time, KEEP2STRAVA[run_data["dataType"]]
                 )
@@ -176,7 +178,9 @@ def parse_raw_data_to_nametuple(
     return namedtuple("x", d.keys())(*d.values())
 
 
-def get_all_keep_tracks(email, password, old_tracks_ids, keep_sports_data_api, with_download_gpx=False):
+def get_all_keep_tracks(
+    email, password, old_tracks_ids, keep_sports_data_api, with_download_gpx=False
+):
     if with_download_gpx and not os.path.exists(GPX_FOLDER):
         os.mkdir(GPX_FOLDER)
     s = requests.Session()
@@ -318,7 +322,9 @@ def download_keep_gpx(gpx_data, keep_id):
 def run_keep_sync(email, password, keep_sports_data_api, with_download_gpx=False):
     generator = Generator(SQL_FILE)
     old_tracks_ids = generator.get_old_tracks_ids()
-    new_tracks = get_all_keep_tracks(email, password, old_tracks_ids, keep_sports_data_api, with_download_gpx)
+    new_tracks = get_all_keep_tracks(
+        email, password, old_tracks_ids, keep_sports_data_api, with_download_gpx
+    )
     generator.sync_from_app(new_tracks)
 
     activities_list = generator.load()
@@ -335,7 +341,7 @@ if __name__ == "__main__":
         dest="sync_types",
         nargs="+",
         default=["running"],
-        help =  "sync sport types from keep, default is running, you can choose from running, hiking, cycling"
+        help="sync sport types from keep, default is running, you can choose from running, hiking, cycling",
     )
     parser.add_argument(
         "--with-gpx",
@@ -345,5 +351,9 @@ if __name__ == "__main__":
     )
     options = parser.parse_args()
     for api in options.sync_types:
-        assert api in KEEP_DATA_TYPE_API, f"{api} are not supported type, please make sure that the type entered in the {KEEP_DATA_TYPE_API}"
-    run_keep_sync(options.phone_number, options.password, options.sync_types, options.with_gpx)
+        assert (
+            api in KEEP_DATA_TYPE_API
+        ), f"{api} are not supported type, please make sure that the type entered in the {KEEP_DATA_TYPE_API}"
+    run_keep_sync(
+        options.phone_number, options.password, options.sync_types, options.with_gpx
+    )

--- a/run_page/keep_sync.py
+++ b/run_page/keep_sync.py
@@ -17,7 +17,7 @@ from generator import Generator
 from utils import adjust_time
 import xml.etree.ElementTree as ET
 
-KEEP_DATA_TYPE_API = ["running", "hiking", "cycling"]
+KEEP_SPORT_TYPES = ["running", "hiking", "cycling"]
 KEEP2STRAVA = {
     "outdoorWalking": "Walk",
     "outdoorRunning": "Run",
@@ -26,8 +26,8 @@ KEEP2STRAVA = {
 }
 # need to test
 LOGIN_API = "https://api.gotokeep.com/v1.1/users/login"
-RUN_DATA_API = "https://api.gotokeep.com/pd/v3/stats/detail?dateUnit=all&type={data_type_api}&lastDate={last_date}"
-RUN_LOG_API = "https://api.gotokeep.com/pd/v3/{data_type_api}log/{run_id}"
+RUN_DATA_API = "https://api.gotokeep.com/pd/v3/stats/detail?dateUnit=all&type={sport_type}&lastDate={last_date}"
+RUN_LOG_API = "https://api.gotokeep.com/pd/v3/{sport_type}log/{run_id}"
 
 HR_FRAME_THRESHOLD_IN_DECISECOND = 100  # Maximum time difference to consider a data point as the nearest, the unit is decisecond(分秒)
 
@@ -50,13 +50,13 @@ def login(session, mobile, password):
         return session, headers
 
 
-def get_to_download_runs_ids(session, headers, data_type_api):
+def get_to_download_runs_ids(session, headers, sport_type):
     last_date = 0
     result = []
 
     while 1:
         r = session.get(
-            RUN_DATA_API.format(data_type_api=data_type_api, last_date=last_date),
+            RUN_DATA_API.format(sport_type=sport_type, last_date=last_date),
             headers=headers,
         )
         if r.ok:
@@ -74,9 +74,9 @@ def get_to_download_runs_ids(session, headers, data_type_api):
     return result
 
 
-def get_single_run_data(session, headers, run_id, data_type_api):
+def get_single_run_data(session, headers, run_id, sport_type):
     r = session.get(
-        RUN_LOG_API.format(data_type_api=data_type_api, run_id=run_id), headers=headers
+        RUN_LOG_API.format(sport_type=sport_type, run_id=run_id), headers=headers
     )
     if r.ok:
         return r.json()
@@ -205,7 +205,7 @@ def get_all_keep_tracks(
     return tracks
 
 
-def parse_points_to_gpx(run_points_data, start_time, type):
+def parse_points_to_gpx(run_points_data, start_time, sport_type):
     """
     Convert run points data to GPX format.
 
@@ -239,7 +239,7 @@ def parse_points_to_gpx(run_points_data, start_time, type):
     gpx.nsmap["gpxtpx"] = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
     gpx_track = gpxpy.gpx.GPXTrack()
     gpx_track.name = "gpx from keep"
-    gpx_track.type = type
+    gpx_track.type = sport_type
     gpx.tracks.append(gpx_track)
 
     # Create first segment in our GPX track:
@@ -350,10 +350,10 @@ if __name__ == "__main__":
         help="get all keep data to gpx and download",
     )
     options = parser.parse_args()
-    for api in options.sync_types:
+    for _tpye in options.sync_types:
         assert (
-            api in KEEP_DATA_TYPE_API
-        ), f"{api} are not supported type, please make sure that the type entered in the {KEEP_DATA_TYPE_API}"
+            _tpye in KEEP_SPORT_TYPES
+        ), f"{_tpye} are not supported type, please make sure that the type entered in the {KEEP_SPORT_TYPES}"
     run_keep_sync(
         options.phone_number, options.password, options.sync_types, options.with_gpx
     )

--- a/run_page/keep_to_strava.py
+++ b/run_page/keep_to_strava.py
@@ -12,7 +12,6 @@ from stravalib.exc import ActivityUploadFailed, RateLimitTimeout
 from utils import make_strava_client, upload_file_to_strava
 from keep_sync import (
     login,
-    get_all_keep_tracks,
     KEEP_DATA_TYPE_API,
     parse_raw_data_to_nametuple,
     get_to_download_runs_ids,
@@ -102,7 +101,6 @@ if __name__ == "__main__":
     )
 
     index = 1
-    print(f"{len(new_tracks)} gpx files is going to upload")
     print(f"Up to {len(new_tracks)} files are waiting to be uploaded")
     uploaded_file_paths = []
     for track in new_tracks:

--- a/run_page/keep_to_strava.py
+++ b/run_page/keep_to_strava.py
@@ -1,158 +1,33 @@
 import argparse
-import base64
 import json
 import os
 from sre_constants import SUCCESS
 import time
-import zlib
 from collections import namedtuple
-from datetime import datetime, timedelta
-
-import eviltransform
-import gpxpy
-import polyline
 import requests
-from config import GPX_FOLDER, JSON_FILE, SQL_FILE, run_map, start_point
+from config import GPX_FOLDER
 from Crypto.Cipher import AES
-from generator import Generator
-from utils import adjust_time
-import xml.etree.ElementTree as ET
 from config import OUTPUT_DIR
 from stravalib.exc import ActivityUploadFailed, RateLimitTimeout
 from utils import make_strava_client, upload_file_to_strava
 from keep_sync import (
-    TIMESTAMP_THRESHOLD_IN_DECISECOND,
-    TRANS_GCJ02_TO_WGS84,
     login,
-    decode_runmap_data,
-    find_nearest_hr,
+    get_all_keep_tracks,
+    KEEP_DATA_TYPE_API,
+    parse_raw_data_to_nametuple,
+    get_to_download_runs_ids,
+    get_single_run_data,
 )
 
 """
-Only provide the ability to sync data from keep's multiple sport types to strava's corresponding sport types to help those who use multiple devices like me, the web page presentation still uses Strava (or refer to nike_to_strava_sync.py to modify it to suit you).
+Only provide the ability to sync data from Keep's multiple sport types to Strava's corresponding sport types to help those who use multiple devices like me, the web page presentation still uses Strava (or refer to nike_to_strava_sync.py to modify it to suit you).
 My own best practices:
 1. running/hiking/Cycling (Huawei/OPPO) -> Keep
 2. Keep -> Strava (add this scripts to run_data_sync.yml)
 3. Road Cycling(Garmin) -> Strava.
 4. running_page(Strava)
 
-
-    """
-KEEP_DATA_TYPE_API = ["running", "hiking", "cycling"]
-KEEP2STRAVA = {
-    "outdoorWalking": "Walk",
-    "outdoorRunning": "Run",
-    "outdoorCycling": "Ride",
-    "indoorRunning": "VirtualRun",
-}
-
-# need to test
-LOGIN_API = "https://api.gotokeep.com/v1.1/users/login"
-RUN_DATA_API = "https://api.gotokeep.com/pd/v3/stats/detail?dateUnit=all&type={data_type_api}&lastDate={last_date}"
-RUN_LOG_API = "https://api.gotokeep.com/pd/v3/{data_type_api}log/{run_id}"
-
-
-def get_to_download_runs_ids(session, headers, data_type_api):
-    last_date = 0
-    result = []
-
-    while 1:
-        r = session.get(
-            RUN_DATA_API.format(data_type_api=data_type_api, last_date=last_date),
-            headers=headers,
-        )
-        if r.ok:
-            run_logs = r.json()["data"]["records"]
-
-            for i in run_logs:
-                logs = [j["stats"] for j in i["logs"]]
-                result.extend(k["id"] for k in logs if not k["isDoubtful"])
-            last_date = r.json()["data"]["lastTimestamp"]
-            since_time = datetime.utcfromtimestamp(last_date / 1000)
-            print(f"pares keep ids data since {since_time}")
-            time.sleep(1)  # spider rule
-            if not last_date:
-                break
-    return result
-
-
-def get_single_run_data(session, headers, run_id, data_type_api):
-    r = session.get(
-        RUN_LOG_API.format(data_type_api=data_type_api, run_id=run_id), headers=headers
-    )
-    if r.ok:
-        return r.json()
-
-
-def download_keep_gpx(gpx_data, keep_id):
-    try:
-        print(f"downloading keep_id {str(keep_id)} gpx")
-        file_path = os.path.join(GPX_FOLDER, str(keep_id) + ".gpx")
-        with open(file_path, "w") as fb:
-            fb.write(gpx_data)
-        return file_path
-    except:
-        print(f"wrong id {keep_id}")
-        pass
-
-
-def parse_points_to_gpx(run_points_data, start_time, type):
-    """
-    Convert run points data to GPX format.
-
-    Args:
-        run_id (str): The ID of the run.
-        run_points_data (list of dict): A list of run data points.
-        start_time (int): The start time for adjusting timestamps. Note that the unit of the start_time is millsecond
-
-    Returns:
-        gpx_data (str): GPX data in string format.
-    """
-    points_dict_list = []
-    # early timestamp fields in keep's data stands for delta time, but in newly data timestamp field stands for exactly time,
-    # so it does'nt need to plus extra start_time
-    if run_points_data[0]["timestamp"] > TIMESTAMP_THRESHOLD_IN_DECISECOND:
-        start_time = 0
-
-    for point in run_points_data:
-        points_dict = {
-            "latitude": point["latitude"],
-            "longitude": point["longitude"],
-            "time": datetime.utcfromtimestamp(
-                (point["timestamp"] * 100 + start_time)
-                / 1000  # note that the timestamp of a point is decisecond(分秒)
-            ),
-            "elevation": point.get("verticalAccuracy"),
-            "hr": point.get("hr"),
-        }
-        points_dict_list.append(points_dict)
-    gpx = gpxpy.gpx.GPX()
-    gpx.nsmap["gpxtpx"] = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
-    gpx_track = gpxpy.gpx.GPXTrack()
-    gpx_track.name = "gpx from keep"
-    gpx_track.type = type
-    gpx.tracks.append(gpx_track)
-
-    # Create first segment in our GPX track:
-    gpx_segment = gpxpy.gpx.GPXTrackSegment()
-    gpx_track.segments.append(gpx_segment)
-    for p in points_dict_list:
-        point = gpxpy.gpx.GPXTrackPoint(
-            latitude=p["latitude"],
-            longitude=p["longitude"],
-            time=p["time"],
-            elevation=p.get("elevation"),
-        )
-        if p.get("hr") is not None:
-            gpx_extension_hr = ET.fromstring(
-                f"""<gpxtpx:TrackPointExtension xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
-                    <gpxtpx:hr>{p["hr"]}</gpxtpx:hr>
-                    </gpxtpx:TrackPointExtension>
-                    """
-            )
-            point.extensions.append(gpx_extension_hr)
-        gpx_segment.points.append(point)
-    return gpx.to_xml()
+"""
 
 
 def get_all_keep_tracks(email, password, old_tracks_ids, with_download_gpx=True):
@@ -174,92 +49,20 @@ def get_all_keep_tracks(email, password, old_tracks_ids, with_download_gpx=True)
                 track = parse_raw_data_to_nametuple(
                     run_data, old_gpx_ids, s, with_download_gpx
                 )
+                # By default only outdoor sports have latlng as well as GPX.
+                if track.start_latlng is not None:
+                    file_path = namedtuple("x", "gpx_file_path")(
+                        os.path.join(GPX_FOLDER, str(track.id) + ".gpx")
+                    )
+                else:
+                    file_path = namedtuple("x", "gpx_file_path")(None)
+                track = namedtuple("y", track._fields + file_path._fields)(
+                    *(track + file_path)
+                )
                 tracks.append(track)
             except Exception as e:
                 print(f"Something wrong paring keep id {run}" + str(e))
     return tracks
-
-
-def parse_raw_data_to_nametuple(run_data, old_gpx_ids, session, with_download_gpx=True):
-    run_data = run_data["data"]
-    run_points_data = []
-
-    # 5898009e387e28303988f3b7_9223370441312156007_rn middle
-    keep_id = run_data["id"].split("_")[1]
-
-    start_time = run_data["startTime"]
-    avg_heart_rate = None
-    decoded_hr_data = []
-    if run_data["heartRate"]:
-        avg_heart_rate = run_data["heartRate"].get("averageHeartRate", None)
-        heart_rate_data = run_data["heartRate"].get("heartRates", None)
-        if heart_rate_data is not None:
-            decoded_hr_data = decode_runmap_data(heart_rate_data)
-        # fix #66
-        if avg_heart_rate and avg_heart_rate < 0:
-            avg_heart_rate = None
-
-    file_path = None
-    if run_data["geoPoints"]:
-        run_points_data = decode_runmap_data(run_data["geoPoints"], True)
-        run_points_data_gpx = run_points_data
-        if TRANS_GCJ02_TO_WGS84:
-            run_points_data = [
-                list(eviltransform.gcj2wgs(p["latitude"], p["longitude"]))
-                for p in run_points_data
-            ]
-            for i, p in enumerate(run_points_data_gpx):
-                p["latitude"] = run_points_data[i][0]
-                p["longitude"] = run_points_data[i][1]
-
-        for p in run_points_data_gpx:
-            p_hr = find_nearest_hr(decoded_hr_data, int(p["timestamp"]), start_time)
-            if p_hr:
-                p["hr"] = p_hr
-        if with_download_gpx:
-            if str(keep_id) not in old_gpx_ids and run_data["dataType"].startswith(
-                "outdoor"
-            ):
-                gpx_data = parse_points_to_gpx(
-                    run_points_data_gpx, start_time, KEEP2STRAVA[run_data["dataType"]]
-                )
-                file_path = download_keep_gpx(gpx_data, str(keep_id))
-    else:
-        print(f"ID {keep_id} no gps data")
-    polyline_str = polyline.encode(run_points_data) if run_points_data else ""
-    start_latlng = start_point(*run_points_data[0]) if run_points_data else None
-    start_date = datetime.utcfromtimestamp(start_time / 1000)
-    tz_name = run_data.get("timezone", "")
-    start_date_local = adjust_time(start_date, tz_name)
-    end = datetime.utcfromtimestamp(run_data["endTime"] / 1000)
-    end_local = adjust_time(end, tz_name)
-    if not run_data["duration"]:
-        print(f"ID {keep_id} has no total time just ignore please check")
-        return
-    d = {
-        "id": int(keep_id),
-        "name": f"{KEEP2STRAVA[run_data['dataType']]} from keep",
-        # future to support others workout now only for run
-        "type": f"{KEEP2STRAVA[(run_data['dataType'])]}",
-        "start_date": datetime.strftime(start_date, "%Y-%m-%d %H:%M:%S"),
-        "end": datetime.strftime(end, "%Y-%m-%d %H:%M:%S"),
-        "start_date_local": datetime.strftime(start_date_local, "%Y-%m-%d %H:%M:%S"),
-        "end_local": datetime.strftime(end_local, "%Y-%m-%d %H:%M:%S"),
-        "length": run_data["distance"],
-        "average_heartrate": int(avg_heart_rate) if avg_heart_rate else None,
-        "map": run_map(polyline_str),
-        "start_latlng": start_latlng,
-        "distance": run_data["distance"],
-        "moving_time": timedelta(seconds=run_data["duration"]),
-        "elapsed_time": timedelta(
-            seconds=int((run_data["endTime"] - run_data["startTime"]) / 1000)
-        ),
-        "average_speed": run_data["distance"] / run_data["duration"],
-        "location_country": str(run_data.get("region", "")),
-        "source": "Keep",
-        "gpx_file_path": file_path,
-    }
-    return namedtuple("x", d.keys())(*d.values())
 
 
 def run_keep_sync(email, password, with_download_gpx=True):
@@ -289,7 +92,7 @@ if __name__ == "__main__":
     parser.add_argument("strava_refresh_token", help="strava refresh token")
 
     options = parser.parse_args()
-    new_tracks = run_keep_sync(options.phone_number, options.password)
+    new_tracks = run_keep_sync(options.phone_number, options.password, True)
 
     # to strava.
     print("Need to load all gpx files maybe take some time")
@@ -300,10 +103,10 @@ if __name__ == "__main__":
 
     index = 1
     print(f"{len(new_tracks)} gpx files is going to upload")
+    print(f"Up to {len(new_tracks)} files are waiting to be uploaded")
     uploaded_file_paths = []
     for track in new_tracks:
         if track.gpx_file_path is not None:
-            print(track.gpx_file_path)
             try:
                 upload_file_to_strava(client, track.gpx_file_path, "gpx", False)
                 uploaded_file_paths.append(track)

--- a/run_page/keep_to_strava.py
+++ b/run_page/keep_to_strava.py
@@ -1,0 +1,351 @@
+import argparse
+import base64
+import json
+import os
+from sre_constants import SUCCESS
+import time
+import zlib
+from collections import namedtuple
+from datetime import datetime, timedelta
+
+import eviltransform
+import gpxpy
+import polyline
+import requests
+from config import GPX_FOLDER, JSON_FILE, SQL_FILE, run_map, start_point
+from Crypto.Cipher import AES
+from generator import Generator
+from utils import adjust_time
+import xml.etree.ElementTree as ET
+from config import OUTPUT_DIR
+from stravalib.exc import ActivityUploadFailed, RateLimitTimeout
+from utils import make_strava_client, upload_file_to_strava
+from keep_sync import (
+    TIMESTAMP_THRESHOLD_IN_DECISECOND,
+    TRANS_GCJ02_TO_WGS84,
+    login,
+    decode_runmap_data,
+    find_nearest_hr,
+)
+
+"""
+Only provide the ability to sync data from keep's multiple sport types to strava's corresponding sport types to help those who use multiple devices like me, the web page presentation still uses Strava (or refer to nike_to_strava_sync.py to modify it to suit you).
+My own best practices:
+1. running/hiking/Cycling (Huawei/OPPO) -> Keep
+2. Keep -> Strava (add this scripts to run_data_sync.yml)
+3. Road Cycling(Garmin) -> Strava.
+4. running_page(Strava)
+
+
+    """
+KEEP_DATA_TYPE_API = ["running", "hiking", "cycling"]
+KEEP2STRAVA = {
+    "outdoorWalking": "Walk",
+    "outdoorRunning": "Run",
+    "outdoorCycling": "Ride",
+    "indoorRunning": "VirtualRun",
+}
+
+# need to test
+LOGIN_API = "https://api.gotokeep.com/v1.1/users/login"
+RUN_DATA_API = "https://api.gotokeep.com/pd/v3/stats/detail?dateUnit=all&type={data_type_api}&lastDate={last_date}"
+RUN_LOG_API = "https://api.gotokeep.com/pd/v3/{data_type_api}log/{run_id}"
+
+
+def get_to_download_runs_ids(session, headers, data_type_api):
+    last_date = 0
+    result = []
+
+    while 1:
+        r = session.get(
+            RUN_DATA_API.format(data_type_api=data_type_api, last_date=last_date),
+            headers=headers,
+        )
+        if r.ok:
+            run_logs = r.json()["data"]["records"]
+
+            for i in run_logs:
+                logs = [j["stats"] for j in i["logs"]]
+                result.extend(k["id"] for k in logs if not k["isDoubtful"])
+            last_date = r.json()["data"]["lastTimestamp"]
+            since_time = datetime.utcfromtimestamp(last_date / 1000)
+            print(f"pares keep ids data since {since_time}")
+            time.sleep(1)  # spider rule
+            if not last_date:
+                break
+    return result
+
+
+def get_single_run_data(session, headers, run_id, data_type_api):
+    r = session.get(
+        RUN_LOG_API.format(data_type_api=data_type_api, run_id=run_id), headers=headers
+    )
+    if r.ok:
+        return r.json()
+
+
+def download_keep_gpx(gpx_data, keep_id):
+    try:
+        print(f"downloading keep_id {str(keep_id)} gpx")
+        file_path = os.path.join(GPX_FOLDER, str(keep_id) + ".gpx")
+        with open(file_path, "w") as fb:
+            fb.write(gpx_data)
+        return file_path
+    except:
+        print(f"wrong id {keep_id}")
+        pass
+
+
+def parse_points_to_gpx(run_points_data, start_time, type):
+    """
+    Convert run points data to GPX format.
+
+    Args:
+        run_id (str): The ID of the run.
+        run_points_data (list of dict): A list of run data points.
+        start_time (int): The start time for adjusting timestamps. Note that the unit of the start_time is millsecond
+
+    Returns:
+        gpx_data (str): GPX data in string format.
+    """
+    points_dict_list = []
+    # early timestamp fields in keep's data stands for delta time, but in newly data timestamp field stands for exactly time,
+    # so it does'nt need to plus extra start_time
+    if run_points_data[0]["timestamp"] > TIMESTAMP_THRESHOLD_IN_DECISECOND:
+        start_time = 0
+
+    for point in run_points_data:
+        points_dict = {
+            "latitude": point["latitude"],
+            "longitude": point["longitude"],
+            "time": datetime.utcfromtimestamp(
+                (point["timestamp"] * 100 + start_time)
+                / 1000  # note that the timestamp of a point is decisecond(分秒)
+            ),
+            "elevation": point.get("verticalAccuracy"),
+            "hr": point.get("hr"),
+        }
+        points_dict_list.append(points_dict)
+    gpx = gpxpy.gpx.GPX()
+    gpx.nsmap["gpxtpx"] = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
+    gpx_track = gpxpy.gpx.GPXTrack()
+    gpx_track.name = "gpx from keep"
+    gpx_track.type = type
+    gpx.tracks.append(gpx_track)
+
+    # Create first segment in our GPX track:
+    gpx_segment = gpxpy.gpx.GPXTrackSegment()
+    gpx_track.segments.append(gpx_segment)
+    for p in points_dict_list:
+        point = gpxpy.gpx.GPXTrackPoint(
+            latitude=p["latitude"],
+            longitude=p["longitude"],
+            time=p["time"],
+            elevation=p.get("elevation"),
+        )
+        if p.get("hr") is not None:
+            gpx_extension_hr = ET.fromstring(
+                f"""<gpxtpx:TrackPointExtension xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
+                    <gpxtpx:hr>{p["hr"]}</gpxtpx:hr>
+                    </gpxtpx:TrackPointExtension>
+                    """
+            )
+            point.extensions.append(gpx_extension_hr)
+        gpx_segment.points.append(point)
+    return gpx.to_xml()
+
+
+def get_all_keep_tracks(email, password, old_tracks_ids, with_download_gpx=True):
+    if with_download_gpx and not os.path.exists(GPX_FOLDER):
+        os.mkdir(GPX_FOLDER)
+    s = requests.Session()
+    s, headers = login(s, email, password)
+    tracks = []
+    for api in KEEP_DATA_TYPE_API:
+        runs = get_to_download_runs_ids(s, headers, api)
+        runs = [run for run in runs if run.split("_")[1] not in old_tracks_ids]
+        print(f"{len(runs)} new keep {api} data to generate")
+        old_gpx_ids = os.listdir(GPX_FOLDER)
+        old_gpx_ids = [i.split(".")[0] for i in old_gpx_ids if not i.startswith(".")]
+        for run in runs:
+            print(f"parsing keep id {run}")
+            try:
+                run_data = get_single_run_data(s, headers, run, api)
+                track = parse_raw_data_to_nametuple(
+                    run_data, old_gpx_ids, s, with_download_gpx
+                )
+                tracks.append(track)
+            except Exception as e:
+                print(f"Something wrong paring keep id {run}" + str(e))
+    return tracks
+
+
+def parse_raw_data_to_nametuple(run_data, old_gpx_ids, session, with_download_gpx=True):
+    run_data = run_data["data"]
+    run_points_data = []
+
+    # 5898009e387e28303988f3b7_9223370441312156007_rn middle
+    keep_id = run_data["id"].split("_")[1]
+
+    start_time = run_data["startTime"]
+    avg_heart_rate = None
+    decoded_hr_data = []
+    if run_data["heartRate"]:
+        avg_heart_rate = run_data["heartRate"].get("averageHeartRate", None)
+        heart_rate_data = run_data["heartRate"].get("heartRates", None)
+        if heart_rate_data is not None:
+            decoded_hr_data = decode_runmap_data(heart_rate_data)
+        # fix #66
+        if avg_heart_rate and avg_heart_rate < 0:
+            avg_heart_rate = None
+
+    file_path = None
+    if run_data["geoPoints"]:
+        run_points_data = decode_runmap_data(run_data["geoPoints"], True)
+        run_points_data_gpx = run_points_data
+        if TRANS_GCJ02_TO_WGS84:
+            run_points_data = [
+                list(eviltransform.gcj2wgs(p["latitude"], p["longitude"]))
+                for p in run_points_data
+            ]
+            for i, p in enumerate(run_points_data_gpx):
+                p["latitude"] = run_points_data[i][0]
+                p["longitude"] = run_points_data[i][1]
+
+        for p in run_points_data_gpx:
+            p_hr = find_nearest_hr(decoded_hr_data, int(p["timestamp"]), start_time)
+            if p_hr:
+                p["hr"] = p_hr
+        if with_download_gpx:
+            if str(keep_id) not in old_gpx_ids and run_data["dataType"].startswith(
+                "outdoor"
+            ):
+                gpx_data = parse_points_to_gpx(
+                    run_points_data_gpx, start_time, KEEP2STRAVA[run_data["dataType"]]
+                )
+                file_path = download_keep_gpx(gpx_data, str(keep_id))
+    else:
+        print(f"ID {keep_id} no gps data")
+    polyline_str = polyline.encode(run_points_data) if run_points_data else ""
+    start_latlng = start_point(*run_points_data[0]) if run_points_data else None
+    start_date = datetime.utcfromtimestamp(start_time / 1000)
+    tz_name = run_data.get("timezone", "")
+    start_date_local = adjust_time(start_date, tz_name)
+    end = datetime.utcfromtimestamp(run_data["endTime"] / 1000)
+    end_local = adjust_time(end, tz_name)
+    if not run_data["duration"]:
+        print(f"ID {keep_id} has no total time just ignore please check")
+        return
+    d = {
+        "id": int(keep_id),
+        "name": f"{KEEP2STRAVA[run_data['dataType']]} from keep",
+        # future to support others workout now only for run
+        "type": f"{KEEP2STRAVA[(run_data['dataType'])]}",
+        "start_date": datetime.strftime(start_date, "%Y-%m-%d %H:%M:%S"),
+        "end": datetime.strftime(end, "%Y-%m-%d %H:%M:%S"),
+        "start_date_local": datetime.strftime(start_date_local, "%Y-%m-%d %H:%M:%S"),
+        "end_local": datetime.strftime(end_local, "%Y-%m-%d %H:%M:%S"),
+        "length": run_data["distance"],
+        "average_heartrate": int(avg_heart_rate) if avg_heart_rate else None,
+        "map": run_map(polyline_str),
+        "start_latlng": start_latlng,
+        "distance": run_data["distance"],
+        "moving_time": timedelta(seconds=run_data["duration"]),
+        "elapsed_time": timedelta(
+            seconds=int((run_data["endTime"] - run_data["startTime"]) / 1000)
+        ),
+        "average_speed": run_data["distance"] / run_data["duration"],
+        "location_country": str(run_data.get("region", "")),
+        "source": "Keep",
+        "gpx_file_path": file_path,
+    }
+    return namedtuple("x", d.keys())(*d.values())
+
+
+def run_keep_sync(email, password, with_download_gpx=True):
+    keep2strava_bk_path = os.path.join(OUTPUT_DIR, "keep2strava.json")
+    if not os.path.exists(keep2strava_bk_path):
+        file = open(keep2strava_bk_path, "w")
+        file.close()
+        content = []
+    else:
+        with open(keep2strava_bk_path) as f:
+            try:
+                content = json.loads(f.read())
+            except:
+                content = []
+    old_tracks_ids = [str(a["run_id"]) for a in content]
+    new_tracks = get_all_keep_tracks(email, password, old_tracks_ids, with_download_gpx)
+
+    return new_tracks
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("phone_number", help="keep login phone number")
+    parser.add_argument("password", help="keep login password")
+    parser.add_argument("client_id", help="strava client id")
+    parser.add_argument("client_secret", help="strava client secret")
+    parser.add_argument("strava_refresh_token", help="strava refresh token")
+
+    options = parser.parse_args()
+    new_tracks = run_keep_sync(options.phone_number, options.password)
+
+    # to strava.
+    print("Need to load all gpx files maybe take some time")
+    last_time = 0
+    client = make_strava_client(
+        options.client_id, options.client_secret, options.strava_refresh_token
+    )
+
+    index = 1
+    print(f"{len(new_tracks)} gpx files is going to upload")
+    uploaded_file_paths = []
+    for track in new_tracks:
+        if track.gpx_file_path is not None:
+            print(track.gpx_file_path)
+            try:
+                upload_file_to_strava(client, track.gpx_file_path, "gpx", False)
+                uploaded_file_paths.append(track)
+            except RateLimitTimeout as e:
+                timeout = e.timeout
+                print(f"Strava API Rate Limit Timeout. Retry in {timeout} seconds\n")
+                time.sleep(timeout)
+                # try previous again
+                upload_file_to_strava(client, track.gpx_file_path, "gpx", False)
+                uploaded_file_paths.append(track)
+            except ActivityUploadFailed as e:
+                print(f"Upload faild error {str(e)}")
+            # spider rule
+            time.sleep(1)
+        else:
+            # for no gps data, like indoorRunning.
+            uploaded_file_paths.append(track)
+    time.sleep(10)
+
+    keep2strava_bk_path = os.path.join(OUTPUT_DIR, "keep2strava.json")
+    with open(keep2strava_bk_path, "r") as f:
+        try:
+            content = json.loads(f.read())
+        except:
+            content = []
+    content.extend(
+        [
+            dict(
+                run_id=track.id,
+                name=track.name,
+                type=track.type,
+                gpx_file_path=track.gpx_file_path,
+            )
+            for track in uploaded_file_paths
+        ]
+    )
+    with open(keep2strava_bk_path, "w") as f:
+        json.dump(content, f, indent=0)
+
+    # del gpx
+    for track in new_tracks:
+        if track.gpx_file_path is not None:
+            os.remove(track.gpx_file_path)
+        else:
+            continue

--- a/run_page/keep_to_strava_sync.py
+++ b/run_page/keep_to_strava_sync.py
@@ -10,10 +10,7 @@ from Crypto.Cipher import AES
 from config import OUTPUT_DIR
 from stravalib.exc import ActivityUploadFailed, RateLimitTimeout
 from utils import make_strava_client, upload_file_to_strava
-from keep_sync import (
-    KEEP_DATA_TYPE_API,
-    get_all_keep_tracks
-)
+from keep_sync import KEEP_DATA_TYPE_API, get_all_keep_tracks
 
 """
 Only provide the ability to sync data from Keep's multiple sport types to Strava's corresponding sport types to help those who use multiple devices like me, the web page presentation still uses Strava (or refer to nike_to_strava_sync.py to modify it to suit you).
@@ -26,7 +23,8 @@ My own best practices:
 """
 KEEP2STRAVA_BK_PATH = os.path.join(OUTPUT_DIR, "keep2strava.json")
 
-def run_keep_sync(email, password, keep_sports_data_api,with_download_gpx=False):
+
+def run_keep_sync(email, password, keep_sports_data_api, with_download_gpx=False):
 
     if not os.path.exists(KEEP2STRAVA_BK_PATH):
         file = open(KEEP2STRAVA_BK_PATH, "w")
@@ -39,7 +37,9 @@ def run_keep_sync(email, password, keep_sports_data_api,with_download_gpx=False)
             except:
                 content = []
     old_tracks_ids = [str(a["run_id"]) for a in content]
-    _new_tracks = get_all_keep_tracks(email, password, old_tracks_ids, keep_sports_data_api, True)
+    _new_tracks = get_all_keep_tracks(
+        email, password, old_tracks_ids, keep_sports_data_api, True
+    )
     new_tracks = []
     for track in _new_tracks:
         # By default only outdoor sports have latlng as well as GPX.
@@ -49,9 +49,7 @@ def run_keep_sync(email, password, keep_sports_data_api,with_download_gpx=False)
             )
         else:
             file_path = namedtuple("x", "gpx_file_path")(None)
-        track = namedtuple("y", track._fields + file_path._fields)(
-            *(track + file_path)
-        )
+        track = namedtuple("y", track._fields + file_path._fields)(*(track + file_path))
         new_tracks.append(track)
 
     return new_tracks
@@ -69,13 +67,17 @@ if __name__ == "__main__":
         dest="sync_types",
         nargs="+",
         default=["running"],
-        help =  "sync sport types from keep, default is running, you can choose from running, hiking, cycling"
+        help="sync sport types from keep, default is running, you can choose from running, hiking, cycling",
     )
 
     options = parser.parse_args()
     for api in options.sync_types:
-        assert api in KEEP_DATA_TYPE_API, f"{api} are not supported type, please make sure that the type entered in the {KEEP_DATA_TYPE_API}"
-    new_tracks = run_keep_sync(options.phone_number, options.password, options.sync_types, True)
+        assert (
+            api in KEEP_DATA_TYPE_API
+        ), f"{api} are not supported type, please make sure that the type entered in the {KEEP_DATA_TYPE_API}"
+    new_tracks = run_keep_sync(
+        options.phone_number, options.password, options.sync_types, True
+    )
 
     # to strava.
     print("Need to load all gpx files maybe take some time")

--- a/run_page/keep_to_strava_sync.py
+++ b/run_page/keep_to_strava_sync.py
@@ -110,11 +110,15 @@ if __name__ == "__main__":
             uploaded_file_paths.append(track)
     time.sleep(10)
 
+    # This file is used to record which logs have been uploaded to strava
+    # to avoid intrusion into the data.db resulting in double counting of data.
     with open(KEEP2STRAVA_BK_PATH, "r") as f:
         try:
             content = json.loads(f.read())
         except:
             content = []
+
+    # Extend and Save the successfully uploaded log to the backup file.
     content.extend(
         [
             dict(
@@ -129,7 +133,7 @@ if __name__ == "__main__":
     with open(KEEP2STRAVA_BK_PATH, "w") as f:
         json.dump(content, f, indent=0)
 
-    # del gpx
+    # del the uploaded GPX file.
     for track in uploaded_file_paths:
         if track.gpx_file_path is not None:
             os.remove(track.gpx_file_path)

--- a/run_page/keep_to_strava_sync.py
+++ b/run_page/keep_to_strava_sync.py
@@ -11,6 +11,7 @@ from config import OUTPUT_DIR
 from stravalib.exc import ActivityUploadFailed, RateLimitTimeout
 from utils import make_strava_client, upload_file_to_strava
 from keep_sync import KEEP_DATA_TYPE_API, get_all_keep_tracks
+from strava_sync import run_strava_sync
 
 """
 Only provide the ability to sync data from Keep's multiple sport types to Strava's corresponding sport types to help those who use multiple devices like me, the web page presentation still uses Strava (or refer to nike_to_strava_sync.py to modify it to suit you).
@@ -139,3 +140,7 @@ if __name__ == "__main__":
             os.remove(track.gpx_file_path)
         else:
             continue
+
+    run_strava_sync(
+        options.client_id, options.client_secret, options.strava_refresh_token
+    )


### PR DESCRIPTION
Only provide the ability to sync data from Keep's multiple sport types to Strava's corresponding sport types, to help those who use multiple devices like me. The web page presentation still uses Strava (or refer to nike_to_strava_sync.py to modify it to suit you). #167 #478 #600 #62 #646 #172 

Specifics:
1. download data from Keep for running, cycling and hiking sport types and generate gpx without intruding into data.db and activities.json.
2. Upload to Strava, automatically recognised as the corresponding sport type (running, cycling, hiking).
3. some fields in the successfully uploaded sports data are logged in activities/keep2strava.json (in order to keep track of whether they have been uploaded or not).
4. Remove the corresponding gpx.

My own best practices:
1. running/hiking (Huawei/OPPO) -> Keep
2. Keep -> Strava
3. cycling(Garmin) -> Strava.
4. running_page(Strava)