### PR TITLE
add an optional `run_from` parameter in `to_namedtuple` method

### DIFF
--- a/run_page/generator/__init__.py
+++ b/run_page/generator/__init__.py
@@ -84,7 +84,9 @@ class Generator:
         synced_files = []
 
         for t in tracks:
-            created = update_or_create_activity(self.session, t.to_namedtuple())
+            created = update_or_create_activity(
+                self.session, t.to_namedtuple(run_from=file_suffix)
+            )
             if created:
                 sys.stdout.write("+")
             else:

--- a/run_page/gpxtrackposter/track.py
+++ b/run_page/gpxtrackposter/track.py
@@ -51,6 +51,7 @@ class Track:
         self.run_id = 0
         self.start_latlng = []
         self.type = "Run"
+        self.device = ""
 
     def load_gpx(self, file_name):
         """
@@ -280,6 +281,14 @@ class Track:
                 self.start_time, self.end_time, None
             )
 
+        # The FIT file created by Garmin
+        if "file_id_mesgs" in fit:
+            device_message = fit["file_id_mesgs"][0]
+            if "manufacturer" in device_message:
+                self.device = device_message["manufacturer"]
+            if "garmin_product" in device_message:
+                self.device += " " + device_message["garmin_product"]
+
     def append(self, other):
         """Append other track to self."""
         self.end_time = other.end_time
@@ -319,10 +328,14 @@ class Track:
             ),
         }
 
-    def to_namedtuple(self):
+    def to_namedtuple(self, run_from="gpx"):
         d = {
             "id": self.run_id,
-            "name": "run from gpx",  # maybe change later
+            "name": (
+                f"run from {run_from} by {self.device}"
+                if self.device
+                else f"run from {run_from}"
+            ),  # maybe change later
             "type": "Run",  # Run for now only support run for now maybe change later
             "start_date": self.start_time.strftime("%Y-%m-%d %H:%M:%S"),
             "end": self.end_time.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
    Modified `Track` class to accept an optional `run_from` parameter in `to_namedtuple` method,

    allowing dynamic naming of activities based on their source.