### PR TITLE
fix: use `KEEP_SPORT_TYPES` instead of `KEEP_DATA_TYPE_API`

### DIFF
--- a/run_page/keep_to_strava_sync.py
+++ b/run_page/keep_to_strava_sync.py
@@ -1,16 +1,13 @@
 import argparse
 import json
 import os
-from sre_constants import SUCCESS
 import time
 from collections import namedtuple
-import requests
 from config import GPX_FOLDER
-from Crypto.Cipher import AES
 from config import OUTPUT_DIR
 from stravalib.exc import ActivityUploadFailed, RateLimitTimeout
 from utils import make_strava_client, upload_file_to_strava
-from keep_sync import KEEP_DATA_TYPE_API, get_all_keep_tracks
+from keep_sync import KEEP_SPORT_TYPES, get_all_keep_tracks
 from strava_sync import run_strava_sync
 
 """
@@ -72,10 +69,10 @@ if __name__ == "__main__":
     )
 
     options = parser.parse_args()
-    for api in options.sync_types:
+    for _tpye in options.sync_types:
         assert (
-            api in KEEP_DATA_TYPE_API
-        ), f"{api} are not supported type, please make sure that the type entered in the {KEEP_DATA_TYPE_API}"
+            _tpye in KEEP_SPORT_TYPES
+        ), f"{_tpye} are not supported type, please make sure that the type entered in the {KEEP_SPORT_TYPES}"
     new_tracks = run_keep_sync(
         options.phone_number, options.password, options.sync_types, True
     )


### PR DESCRIPTION
Corrected import in `keep_to_strava_sync.py` to use `KEEP_SPORT_TYPES` instead of `KEEP_DATA_TYPE_API`.