### PR TITLE
Some Front Optimization for Keep indoor data

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "data:clean": "rm run_page/data.db {GPX,TCX,FIT}_OUT/* activities/* src/static/activities.json",
+    "data:clean": "rm -f run_page/data.db {GPX,TCX,FIT}_OUT/* activities/* src/static/activities.json",
     "data:download:garmin": "python3 run_page/garmin_sync.py",
     "data:analysis": "python3 run_page/gen_svg.py --from-db --type github --output assets/github.svg",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Yi hong",
   "version": "1.0.0",
   "author": "Yi Hong <zouzou0208@gmail.com>",
+  "packageManager": "pnpm@8.9.0+sha256.8f5264ad1d100da11a6add6bb8a94c6f1e913f9e9261b2a551fabefad2ec0fec",
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^1.0.0",
     "@mapbox/polyline": "^1.1.1",

--- a/run_page/keep_sync.py
+++ b/run_page/keep_sync.py
@@ -112,7 +112,7 @@ def parse_raw_data_to_nametuple(
     if run_data["heartRate"]:
         avg_heart_rate = run_data["heartRate"].get("averageHeartRate", None)
         heart_rate_data = run_data["heartRate"].get("heartRates", None)
-        if heart_rate_data is not None:
+        if heart_rate_data:
             decoded_hr_data = decode_runmap_data(heart_rate_data)
         # fix #66
         if avg_heart_rate and avg_heart_rate < 0:

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -137,6 +137,7 @@ const locationForRun = (
     }
     if (provinceMatch) {
       [province] = provinceMatch;
+      // try to extract city coord from location_country info
       coordinate = extractCoordinate(location);
     }
     const l = location.split(',');
@@ -179,6 +180,7 @@ const pathForRun = (run: Activity): Coordinate[] => {
         ? [arr[1], arr[0]]
         : gcoord.transform([arr[1], arr[0]], gcoord.GCJ02, gcoord.WGS84);
     });
+    // try to use location city coordinate instead , if runpath is incomplete
     if (c.length === 2 && String(c[0]) === String(c[1])) {
       const { coordinate } = locationForRun(run);
       if (coordinate?.[0] && coordinate?.[1]) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -36,9 +36,8 @@ const titleForShow = (run: Activity): string => {
   if (run.name) {
     name = run.name;
   }
-  return `${name} ${date} ${distance} KM ${
-    !run.summary_polyline ? '(No map data for this run)' : ''
-  }`;
+  return `${name} ${date} ${distance} KM ${!run.summary_polyline ? '(No map data for this run)' : ''
+    }`;
 };
 
 const formatPace = (d: number): string => {
@@ -93,7 +92,21 @@ const extractLocations = (str: string): string[] => {
   return locations;
 };
 
+const extractCoordinate = (str: string): [number, number] | null => {
+  const pattern = /'latitude': ([-]?\d+\.\d+).*?'longitude': ([-]?\d+\.\d+)/;
+  const match = str.match(pattern);
+
+  if (match) {
+    const latitude = parseFloat(match[1]);
+    const longitude = parseFloat(match[2]);
+    return [longitude, latitude];
+  }
+
+  return null;
+};
+
 const cities = chinaCities.map((c) => c.name);
+const locationCache = new Map<number, ReturnType<typeof locationForRun>>();
 // what about oversea?
 const locationForRun = (
   run: Activity
@@ -101,9 +114,14 @@ const locationForRun = (
   country: string;
   province: string;
   city: string;
+  coordinate: [number, number] | null;
 } => {
+  if (locationCache.has(run.run_id)) {
+    return locationCache.get(run.run_id)!;
+  }
   let location = run.location_country;
   let [city, province, country] = ['', '', ''];
+  let coordinate = null;
   if (location) {
     // Only for Chinese now
     // should filter 臺灣
@@ -119,6 +137,7 @@ const locationForRun = (
     }
     if (provinceMatch) {
       [province] = provinceMatch;
+      coordinate = extractCoordinate(location);
     }
     const l = location.split(',');
     // or to handle keep location format
@@ -136,7 +155,9 @@ const locationForRun = (
     province = city;
   }
 
-  return { country, province, city };
+  const r = { country, province, city, coordinate };
+  locationCache.set(run.run_id, r);
+  return r;
 };
 
 const intComma = (x = '') => {
@@ -158,6 +179,12 @@ const pathForRun = (run: Activity): Coordinate[] => {
         ? [arr[1], arr[0]]
         : gcoord.transform([arr[1], arr[0]], gcoord.GCJ02, gcoord.WGS84);
     });
+    if (c.length === 2 && String(c[0]) === String(c[1])) {
+      const { coordinate } = locationForRun(run);
+      if (coordinate?.[0] && coordinate?.[1]) {
+        return [coordinate, coordinate];
+      }
+    }
     return c;
   } catch (err) {
     return [];
@@ -183,9 +210,9 @@ const geoJsonForRuns = (runs: Activity[]): FeatureCollection<LineString> => ({
 });
 
 const geoJsonForMap = (): FeatureCollection<RPGeometry> => ({
-    type: 'FeatureCollection',
-    features: worldGeoJson.features.concat(chinaGeojson.features),
-  })
+  type: 'FeatureCollection',
+  features: worldGeoJson.features.concat(chinaGeojson.features),
+})
 
 const titleForRun = (run: Activity): string => {
   const runDistance = run.distance / 1000;
@@ -231,6 +258,9 @@ const getBoundsForGeoData = (
   }
   if (points.length === 0) {
     return { longitude: 20, latitude: 20, zoom: 3 };
+  }
+  if (points.length === 2 && String(points[0]) === String(points[1])) {
+    return { longitude: points[0][0], latitude: points[0][1], zoom: 9 };
   }
   // Calculate corner values of bounds
   const pointsLong = points.map((point) => point[0]) as number[];

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -106,7 +106,7 @@ const locationForRun = (
   let [city, province, country] = ['', '', ''];
   if (location) {
     // Only for Chinese now
-    // should fiter 臺灣
+    // should filter 臺灣
     const cityMatch = extractLocations(location);
     const provinceMatch = location.match(/[\u4e00-\u9fa5]{2,}(省|自治区)/);
 


### PR DESCRIPTION
hi , yihong
I export  some keep records , almost indoor run data  🫣. 
the geoPoints is empty or looks incomplete decoded data, 
i prefer the bounds is dalian(from location_country) not beijing.

btw the part of the keep data is : 
```
  {
    "run_id": 9223370384358951307,
    "name": "VirtualRun from keep",
    "distance": 7095.168620939273,
    "moving_time": "21:28:40",
    "type": "VirtualRun",
    "start_date": "2022-05-13 05:08:24",
    "start_date_local": "2022-05-13 13:08:24",
    "location_country": "{'latitude': 38.858706, 'longitude': 121.52418, 'country': '\u4e2d\u56fd', 'nationCode': '156', 'province': '\u8fbd\u5b81\u7701', 'city': '\u5927\u8fde\u5e02', 'cityCode': '0411', 'district': None, 'districtCode': None, 'startLatitude': 0.0, 'startLongitude': 0.0}",
    "summary_polyline": "gqqrFsrkeU??", // or null
    "average_heartrate": null,
    "average_speed": 0.09176369142446034,
    "streak": 1
  }
```

> if "summary_polyline" === "gqqrFsrkeU??", decoded coord is beijing. 