### PR TITLE
Fix AttributeError in Activity class

### DIFF
--- a/run_page/generator/__init__.py
+++ b/run_page/generator/__init__.py
@@ -64,7 +64,10 @@ class Generator:
             if self.only_run and activity.type != "Run":
                 continue
             if IGNORE_BEFORE_SAVING:
-                activity.summary_polyline = filter_out(activity.summary_polyline)
+                if activity.map and activity.map.summary_polyline:
+                    activity.map.summary_polyline = filter_out(
+                        activity.map.summary_polyline
+                    )
             created = update_or_create_activity(self.session, activity)
             if created:
                 sys.stdout.write("+")


### PR DESCRIPTION
When enable IGNORE_BEFORE_SAVING, workflow run failed:

```
Run python run_page/strava_sync.py *** *** ***
Traceback (most recent call last):
  File "/home/runner/work/workouts_page/workouts_page/run_page/strava_sync.py", line 33, in <module>
Access ok
    run_strava_sync(
  File "/home/runner/work/workouts_page/workouts_page/run_page/strava_sync.py", line 14, in run_strava_sync
    generator.sync(False)
  File "/home/runner/work/workouts_page/workouts_page/run_page/generator/__init__.py", line 68, in sync
    activity.summary_polyline = filter_out(activity.summary_polyline)
AttributeError: 'Activity' object has no attribute 'summary_polyline'
Start syncing
Error: Process completed with exit code 1.
```

Sorry, this is my first time using PR. 
I accidentally submitted my own changes just now. I created a new branch to submit the modifications. 
I appreciate it if you could review it again.