### PR TITLE
feat: conditionally output analysis JS only in Vercel environment

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -208,7 +208,7 @@ const Index = () => {
         )}
       </div>
       {/* Enable Audiences in Vercel Analytics: https://vercel.com/docs/concepts/analytics/audiences/quickstart */}
-      <Analytics />
+      {import.meta.env.VERCEL && <Analytics /> }
     </Layout>
   );
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
     }),
   ],
   base: process.env.PATH_PREFIX || '/',
+  define: {
+    "import.meta.env.VERCEL": JSON.stringify(process.env.VERCEL),
+  },
   build: {
     manifest: true,
     outDir: './dist', // for user easy to use, vercel use default dir -> dist


### PR DESCRIPTION
In non-Vercel deployment environments(Github Pages), there will be a 404 request for the Vercel Analytics JS.

![WX20240922-194600@2x](https://github.com/user-attachments/assets/40d6260f-dc12-43ca-9bbc-57ed5c305e5c)

After modification, output under Vercel deployment:

![WX20240922-215504@2x](https://github.com/user-attachments/assets/caaf4340-4125-4b75-9b11-cefb2810c764)

output non-Vercel deployment:

![WX20240922-215720@2x](https://github.com/user-attachments/assets/b7b0ebae-82e6-4bf8-a1e6-c96137ea09d4)
