### PR TITLE
fix: `FullscreenControl` is not fullscreen until resizing window

### DIFF
--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -136,6 +136,7 @@ const RunMap = ({
       mapStyle="mapbox://styles/mapbox/dark-v10"
       ref={mapRefCallback}
       mapboxAccessToken={MAPBOX_TOKEN}
+      onRender={(event) => event.target.resize()}
     >
       <RunMapButtons changeYear={changeYear} thisYear={thisYear} />
       <Source id="data" type="geojson" data={geoData}>


### PR DESCRIPTION
When my browser is already fullscreen, clicking `FullscreenControl` the map doesn't fill the entire screen.

- before
	
https://github.com/user-attachments/assets/26c83240-dac6-415c-a430-e6a579069259

- after
	
https://github.com/user-attachments/assets/820d130f-cb57-4c6a-b7f7-78411f080d52

