### PR TITLE
fix: tracks color

### DIFF
--- a/run_page/gpxtrackposter/tracks_drawer.py
+++ b/run_page/gpxtrackposter/tracks_drawer.py
@@ -47,7 +47,10 @@ class TracksDrawer:
         diff = length_range.diameter()
         if diff == 0:
             return color1
-        if self.poster.length_range.upper() / 1000 < self.poster.special_distance["special_distance2"]:
+        if (
+            self.poster.length_range.upper() / 1000
+            < self.poster.special_distance["special_distance2"]
+        ):
             return color1
 
         return interpolate_color(color1, color2, (length - length_range.lower()) / diff)

--- a/run_page/gpxtrackposter/tracks_drawer.py
+++ b/run_page/gpxtrackposter/tracks_drawer.py
@@ -47,5 +47,7 @@ class TracksDrawer:
         diff = length_range.diameter()
         if diff == 0:
             return color1
+        if self.poster.length_range.upper() / 1000 < self.poster.special_distance["special_distance2"]:
+            return color1
 
         return interpolate_color(color1, color2, (length - length_range.lower()) / diff)


### PR DESCRIPTION
- issue [Total 统计图 格子颜色不对](https://github.com/yihong0618/running_page/issues/725)
- Because there are two special distances, when there is only one, `interpolate_color` is wrong. The solution is to check whether `special_distance2` is greater than `length_range.upper()`. If it is greater, return `color1`