### PR TITLE
fixed a bug where incremental uploads failed

### DIFF
--- a/run_page/garmin_sync_cn_global.py
+++ b/run_page/garmin_sync_cn_global.py
@@ -5,23 +5,13 @@ Copy most code from https://github.com/cyberjunky/python-garminconnect
 
 import argparse
 import asyncio
-import logging
 import os
 import sys
-import time
-import traceback
-import zipfile
-from io import BytesIO
 
-import aiofiles
-import cloudscraper
-import garth
-import httpx
+
 from config import FIT_FOLDER, GPX_FOLDER, JSON_FILE, SQL_FILE, config
-from garmin_device_adaptor import wrap_device_info
 from garmin_sync import Garmin, get_downloaded_ids
 from garmin_sync import download_new_activities, gather_with_concurrency
-from synced_data_file_logger import load_synced_activity_list, save_synced_activity_list
 from utils import make_activities_file
 
 if __name__ == "__main__":
@@ -53,7 +43,9 @@ if __name__ == "__main__":
     # If the activity is manually imported with a GPX, the GPX file will be synced
 
     # load synced activity list
-    synced_activity = load_synced_activity_list()
+    downloaded_fit = get_downloaded_ids(FIT_FOLDER)
+    downloaded_gpx = get_downloaded_ids(GPX_FOLDER)
+    downloaded_activity = list(set(downloaded_fit + downloaded_gpx))
 
     folder = FIT_FOLDER
     # make gpx or tcx dir
@@ -65,7 +57,7 @@ if __name__ == "__main__":
         download_new_activities(
             secret_string_cn,
             auth_domain,
-            synced_activity,
+            downloaded_activity,
             is_only_running,
             folder,
             "fit",
@@ -94,10 +86,6 @@ if __name__ == "__main__":
         garmin_global_client.upload_activities_files(to_upload_files)
     )
     loop.run_until_complete(future)
-
-    # Save synced activity list for speeding up
-    synced_activity.extend(new_ids)
-    save_synced_activity_list(synced_activity)
 
     # Step 2:
     # Generate track from fit/gpx file

--- a/run_page/synced_data_file_logger.py
+++ b/run_page/synced_data_file_logger.py
@@ -12,11 +12,6 @@ def save_synced_data_file_list(file_list: list):
         json.dump(file_list, f)
 
 
-def save_synced_activity_list(activity_list: list):
-    with open(SYNCED_ACTIVITY_FILE, "w") as f:
-        json.dump(activity_list, f)
-
-
 def load_synced_file_list():
     if os.path.exists(SYNCED_FILE):
         with open(SYNCED_FILE, "r") as f:
@@ -24,18 +19,6 @@ def load_synced_file_list():
                 return json.load(f)
             except Exception as e:
                 print(f"json load {SYNCED_FILE} \nerror {e}")
-                pass
-
-    return []
-
-
-def load_synced_activity_list():
-    if os.path.exists(SYNCED_ACTIVITY_FILE):
-        with open(SYNCED_ACTIVITY_FILE, "r") as f:
-            try:
-                return json.load(f)
-            except Exception as e:
-                print(f"json load {SYNCED_ACTIVITY_FILE} \nerror {e}")
                 pass
 
     return []


### PR DESCRIPTION
In the previous version, the synced_activity.json is not stored in the github actions cache. In this commit, it no longer relies on the synced_activity.json but gets downloaded_ids directly from FIT_OUT and GPX_OUT in the same way with garmin_sync.