### PR TITLE
Python 3.7 to 3.11 in Cloudflare

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1071,7 +1071,7 @@ python3(python) run_page/gen_svg.py --from-db --type circular --use-localtime
 
 5. 下滑点击 `环境变量 (高级)`，并添加一个如下的变量：
 
-   > 变量名称 = `PYTHON_VERSION`, 值 = `3.8`
+   > 变量名称 = `PYTHON_VERSION`, 值 = `3.11`
 
 6. 点击 `保存并部署`，完成部署。
 

--- a/README.md
+++ b/README.md
@@ -849,7 +849,7 @@ For more display effects, see:
 
 5. Scroll down, click `Environment variables (advanced)`, then add a variable like the below:
 
-   > Variable name = `PYTHON_VERSION`, Value = `3.7`
+   > Variable name = `PYTHON_VERSION`, Value = `3.11`
 
 6. Click `Save and Deploy`
 


### PR DESCRIPTION
Python 3.7 does not work properly in Cloudflare, whereas Python 3.11 does.