### PR TITLE
fix Dockerfile: package manager from yarn->pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY ./pnpm-lock.yaml /root/running_page/pnpm-lock.yaml
 RUN npm config rm proxy&&npm config set registry https://registry.npmjs.org/ \
   &&npm install -g corepack \
   &&corepack enable \
-  &&yarn install
+  &&pnpm install
 
 FROM develop-py AS data
 ARG app
@@ -61,7 +61,7 @@ RUN python3 run_page/gen_svg.py --from-db --title "my running page" --type grid 
 FROM develop-node AS frontend-build
 WORKDIR /root/running_page
 COPY --from=data /root/running_page /root/running_page
-RUN yarn run build
+RUN pnpm run build
 
 FROM nginx:alpine AS web
 COPY --from=frontend-build /root/running_page/dist /usr/share/nginx/html/


### PR DESCRIPTION
现有的版本的Dockerfile在build的时候报错如下：
```
=> ERROR [develop-node 5/5] RUN npm config rm proxy&&npm config set registry https://registry.npmjs.org/   &&npm install -g corepack   &&corepack enable   &&yarn install                                                                          1.7s
------                                                                                                                                                                                                                                                   
 > [develop-node 5/5] RUN npm config rm proxy&&npm config set registry https://registry.npmjs.org/   &&npm install -g corepack   &&corepack enable   &&yarn install:                                                                                     
1.365                                                                                                                                                                                                                                                    
1.365 changed 1 package in 619ms                                                                                                                                                                                                                         
1.638 /usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22379                                                                                                                                                                                   
1.638               throw new UsageError(`This project is configured to use ${result.spec.name} because ${result.target} has a "packageManager" field`);                                                                                                 
1.638                     ^
1.638 
1.638 UsageError: This project is configured to use pnpm because /root/running_page/package.json has a "packageManager" field
1.638     at Engine.findProjectSpec (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22379:21)
1.638     at async Engine.executePackageManagerRequest (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22410:24)
1.638     at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23102:5) {
1.638   clipanion: { type: 'usage' }
1.638 }
1.638 
1.638 Node.js v18.20.5
------
Dockerfile:21
--------------------
  20 |     COPY ./pnpm-lock.yaml /root/running_page/pnpm-lock.yaml
  21 | >>> RUN npm config rm proxy&&npm config set registry https://registry.npmjs.org/ \
  22 | >>>   &&npm install -g corepack \
  23 | >>>   &&corepack enable \
  24 | >>>   &&yarn install
  25 |     
--------------------
```

对比了一下README里面的安装描述发现已经使用了pnpm进行管理（去学习了一下npm，yarn，pnpm以及corepack，前端的版本管理真的是复杂和多变）

通过修改，此commit已经可以build和run～

BTW：后续打算优化一下Dockerfile，这里把secret敏感信息build到镜像里面不是一个好方式，没办法进行传播，应该build一个通用的image，可以对齐每个commit，大家可以在使用image的时候进行相关的初始化和部署～

新的一年决定切换到Strava，使用running page～
![image](https://github.com/user-attachments/assets/606e9e34-30ef-4d41-a93d-df7c5df11a72)


