### PR TITLE
fix: Enable persist-credentials to resolve authentication failure in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Set up Python ${{ matrix.python-version }}
         id: setup_python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         id: setup_python

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -1,7 +1,7 @@
-name: Run Data Sync
+﻿name: Run Data Sync
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
   push:
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Set up Python
         id: setup_python


### PR DESCRIPTION
**问题背景** 
 
在 GitHub Actions 工作流中，当尝试执行 `git push` 时，遇到以下错误：  
`fatal: could not read Username for 'https://github.com': No such device or address`  
经排查，此问题是由于 `actions/checkout@v4` 默认关闭了凭据持久化 (`persist-credentials: false`)，导致后续 Git 操作无法自动使用 `GITHUB_TOKEN` 认证。

**改动内容**  

- 在 `actions/checkout` 步骤中显式设置 `persist-credentials: true`。  
- 此配置会保存 `GITHUB_TOKEN` 凭据，确保后续 `git push` 操作通过认证。  

**测试结果**  

- 修改后，工作流成功推送更改至仓库 [Run Data Sync · viazure/running_page@d82985d](https://github.com/viazure/running_page/actions/runs/13351482128)）。  