### PR TITLE
fix: joyrun duplicate check logic

### DIFF
--- a/run_page/joyrun_sync.py
+++ b/run_page/joyrun_sync.py
@@ -350,11 +350,11 @@ class Joyrun:
                     break
             if not is_duplicate:
                 seen_runs[start_time] = {"run_data": run_data, "distance": distance}
-            for run in seen_runs.values():
-                track = self.parse_raw_data_to_nametuple(
-                    run["run_data"], old_gpx_ids, with_gpx
-                )
-                tracks.append(track)
+        for run in seen_runs.values():
+            track = self.parse_raw_data_to_nametuple(
+                run["run_data"], old_gpx_ids, with_gpx
+            )
+            tracks.append(track)
         return tracks
 
 


### PR DESCRIPTION
The duplicate check #757 logic should exclude the track generation part to avoid unnecessary track generation processes. 