### PR TITLE
fix: handle None values for elevation gain in activity updates

### DIFF
--- a/run_page/generator/db.py
+++ b/run_page/generator/db.py
@@ -124,7 +124,11 @@ def update_or_create_activity(session, run_activity):
                 location_country=location_country,
                 average_heartrate=run_activity.average_heartrate,
                 average_speed=float(run_activity.average_speed),
-                elevation_gain=float(run_activity.elevation_gain),
+                elevation_gain=(
+                    float(run_activity.elevation_gain)
+                    if run_activity.elevation_gain is not None
+                    else None
+                ),
                 summary_polyline=(
                     run_activity.map and run_activity.map.summary_polyline or ""
                 ),
@@ -140,7 +144,11 @@ def update_or_create_activity(session, run_activity):
             activity.subtype = run_activity.subtype
             activity.average_heartrate = run_activity.average_heartrate
             activity.average_speed = float(run_activity.average_speed)
-            activity.elevation_gain = float(run_activity.elevation_gain)
+            activity.elevation_gain = (
+                float(run_activity.elevation_gain)
+                if run_activity.elevation_gain is not None
+                else None
+            )
             activity.summary_polyline = (
                 run_activity.map and run_activity.map.summary_polyline or ""
             )


### PR DESCRIPTION
fix below error
```log
something wrong with 1084242294
float() argument must be a string or a real number, not 'NoneType'
```