### PR TITLE
bugfix: fix wrong "type" value when load Garmin gpx file.

### DIFF
--- a/run_page/gpxtrackposter/track.py
+++ b/run_page/gpxtrackposter/track.py
@@ -207,7 +207,7 @@ class Track:
             if self.track_name is None:
                 self.track_name = t.name
             if hasattr(t, "type") and t.type:
-                self.type = t.type
+                self.type = "Run" if t.type == "running" else t.type
             for s in t.segments:
                 try:
                     extensions = [


### PR DESCRIPTION
fix issue: #851

> When a Garmin GPX file is loaded into data.db, the "type" field is stored as "running". However, many features — such as the summary page — expect the type to be "Run", so they do not work correctly.