### PR TITLE
Fix inconsistency between activity file and mapbox layer in country name

### DIFF
--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -1,6 +1,18 @@
 import { locationForRun, titleForRun } from '@/utils/utils';
 import activities from '@/static/activities.json';
 
+// standardize country names for consistency between mapbox and activities data
+const standardizeCountryName = (country: string): string => {
+  switch (country) {
+    case '英国 / 英國':
+      return '英国';
+    case '美利坚合众国/美利堅合眾國':
+      return '美国';
+    default:
+      return country;
+    }
+}
+
 const useActivities = () => {
   const cities: Record<string, number> = {};
   const runPeriod: Record<string, number> = {};
@@ -25,7 +37,7 @@ const useActivities = () => {
       cities[city] = cities[city] ? cities[city] + run.distance : run.distance;
     }
     if (province) provinces.add(province);
-    if (country) countries.add(country);
+    if (country) countries.add(standardizeCountryName(country));
     const year = run.start_date_local.slice(0, 4);
     years.add(year);
   });


### PR DESCRIPTION
Fixed https://github.com/yihong0618/running_page/issues/782

The root cause is the inconsistency in country names between activity file and mapbox layers. For example, USA in activity file will be "美利坚合众国/美利堅合眾國" but only "美国" works for mapbox. Another example is "英国 / 英國" and "英国".

The function `standardizeCountryName` can be extended to other countries later.