### PR TITLE
feat: add support for more map tile styles.

### DIFF
--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -10,7 +10,6 @@ import Map, {
 import { MapInstance } from 'react-map-gl/src/types/lib';
 import useActivities from '@/hooks/useActivities';
 import {
-  MAP_LAYER_LIST,
   IS_CHINESE,
   ROAD_LABEL_DISPLAY,
   MAPBOX_TOKEN,
@@ -21,8 +20,11 @@ import {
   MAP_HEIGHT,
   PRIVACY_MODE,
   LIGHTS_ON,
+  MAP_TILE_STYLE,
+  MAP_TILE_VENDOR,
+  MAP_TILE_ACCESS_TOKEN,
 } from '@/utils/const';
-import { Coordinate, IViewState, geoJsonForMap } from '@/utils/utils';
+import { Coordinate, IViewState, geoJsonForMap, getMapStyle } from '@/utils/utils';
 import RunMarker from './RunMarker';
 import RunMapButtons from './RunMapButtons';
 import styles from './style.module.css';
@@ -52,6 +54,8 @@ const RunMap = ({
   const mapRef = useRef<MapRef>();
   const [lights, setLights] = useState(PRIVACY_MODE ? false : LIGHTS_ON);
   const keepWhenLightsOff = ['runs2'];
+  const mapStyle = getMapStyle(MAP_TILE_VENDOR, MAP_TILE_STYLE, MAP_TILE_ACCESS_TOKEN);
+
   function switchLayerVisibility(map: MapInstance, lights: boolean) {
     const styleJson = map.getStyle();
     styleJson.layers.forEach((it: { id: string }) => {
@@ -70,9 +74,16 @@ const RunMap = ({
         }
         // all style resources have been downloaded
         // and the first visually complete rendering of the base style has occurred.
-        map.on('style.load', () => {
+        // it's odd. when use style other than mapbox, the style.load event is not triggered.Add commentMore actions
+        // so I use data event instead of style.load event and make sure we handle it only once.
+        map.on('data', event => {
+          if (event.dataType !== 'style' || mapRef.current) {
+            return;
+          }
           if (!ROAD_LABEL_DISPLAY) {
-            MAP_LAYER_LIST.forEach((layerId) => {
+            const layers = map.getStyle().layers;
+            const labelLayerNames = layers.filter((layer: any) => (layer.type === 'symbol' || layer.type === 'composite') && layer.layout.text_field !== null).map((layer: any) => layer.id);
+            labelLayerNames.forEach((layerId) => {
               map.removeLayer(layerId);
             });
           }
@@ -152,7 +163,7 @@ const RunMap = ({
       {...viewState}
       onMove={onMove}
       style={style}
-      mapStyle="mapbox://styles/mapbox/dark-v10"
+      mapStyle={mapStyle}
       ref={mapRefCallback}
       mapboxAccessToken={MAPBOX_TOKEN}
     >

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -166,3 +166,38 @@ export const CYCLING_COLOR = 'rgb(51,255,87)';
 export const HIKING_COLOR = 'rgb(151,51,255)';
 export const WALKING_COLOR = HIKING_COLOR;
 export const SWIMMING_COLOR = 'rgb(255,51,51)';
+
+// map tiles vendor, maptiler or mapbox or stadiamaps
+// if you want to use maptiler, set the access token in MAP_TILE_ACCESS_TOKEN
+export const MAP_TILE_VENDOR = "mapbox";
+
+// map tiles style name, see MAP_TILE_STYLES for more details
+export const MAP_TILE_STYLE = "dark-v10";
+
+// access token. you can apply a new one, it's free.
+// maptiler: Gt5R0jT8tuIYxW6sNrAg | sign up at https://cloud.maptiler.com/auth/widget
+// stadiamaps: 8a769c5a-9125-4936-bdcf-a6b90cb5d0a4 |sign up at https://client.stadiamaps.com/signup/
+export const MAP_TILE_ACCESS_TOKEN = "Gt5R0jT8tuIYxW6sNrAg";
+
+export const MAP_TILE_STYLES = {
+  maptiler: {
+    "dataviz-dark": "https://api.maptiler.com/maps/dataviz-dark/style.json?key=",
+    "basic-dark": "https://api.maptiler.com/maps/basic-v2-dark/style.json?key=",
+    "streets-dark": "https://api.maptiler.com/maps/streets-v2-dark/style.json?key=",
+    "outdoor-dark": "https://api.maptiler.com/maps/outdoor-v2-dark/style.json?key=",
+    "bright-dark": "https://api.maptiler.com/maps/bright-v2-dark/style.json?key=",
+    "topo-dark": "https://api.maptiler.com/maps/topo-v2-dark/style.json?key=",
+    "winter-dark": "https://api.maptiler.com/maps/winter-v2-dark/style.json?key=",
+    "hybrid": "https://api.maptiler.com/maps/hybrid/style.json?key="
+  },
+  stadiamaps: {
+    "alidade_smooth_dark": "https://tiles.stadiamaps.com/styles/alidade_smooth_dark.json?api_key=",
+    "alidade_satellite": "https://tiles.stadiamaps.com/styles/alidade_satellite.json?api_key=",
+  },
+  mapbox: {
+    "dark-v10": "mapbox://styles/mapbox/dark-v10",
+    "dark-v11": "mapbox://styles/mapbox/dark-v11",
+    "navigation-night": "mapbox://styles/mapbox/navigation-night-v1"
+  },
+  default: "mapbox://styles/mapbox/dark-v10"
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -17,6 +17,7 @@ import {
   SWIMMING_COLOR,
   RUN_COLOR,
   RUN_TRAIL_COLOR,
+  MAP_TILE_STYLES
 } from './const';
 import {
   FeatureCollection,
@@ -423,6 +424,17 @@ const sortDateFunc = (a: Activity, b: Activity) => {
 };
 const sortDateFuncReverse = (a: Activity, b: Activity) => sortDateFunc(b, a);
 
+const getMapStyle = (vendor: string, styleName: string, token: string) => {
+  const style = (MAP_TILE_STYLES as any)[vendor][styleName];
+  if (!style)  {
+    return MAP_TILE_STYLES.default;
+  }
+  if (vendor === "maptiler" || vendor === "stadiamaps") {
+    return style + token;
+  }
+  return style;
+}
+
 export {
   titleForShow,
   formatPace,
@@ -442,4 +454,5 @@ export {
   getBoundsForGeoData,
   formatRunTime,
   convertMovingTime2Sec,
+  getMapStyle,
 };


### PR DESCRIPTION
Add Support for Additional Map Tile Styles
The supported map tile providers include Mapbox, MapTiler, and Stadia Maps.
To change the default map tile style, configure the following keys in const.ts:

```javascript
export const MAP_TILE_VENDOR = "maptiler";
export const MAP_TILE_STYLE = "winter-dark";
export const MAP_TILE_ACCESS_TOKEN = "Gt5R0jT8tuIYxW6sNrAg";
````
