### PR TITLE
fix: Remove activity merging for start times within one hour

### DIFF
--- a/run_page/gpxtrackposter/track_loader.py
+++ b/run_page/gpxtrackposter/track_loader.py
@@ -92,9 +92,6 @@ class TrackLoader:
         log.info(f"Conventionally loaded tracks: {len(loaded_tracks)}")
 
         tracks = self._filter_tracks(tracks)
-
-        # merge tracks that took place within one hour
-        tracks = self._merge_tracks(tracks)
         # filter out tracks with length < min_length
         return [t for t in tracks if t.length >= self.min_length]
 


### PR DESCRIPTION
Fix #888 .

As titled.

It's common that two activities has start_time less than one hour.