### PR TITLE
feat: support gxp and tcx file for Coros.

### DIFF
--- a/run_page/coros_sync.py
+++ b/run_page/coros_sync.py
@@ -7,19 +7,13 @@ import time
 import aiofiles
 import httpx
 
-from config import JSON_FILE, SQL_FILE, FIT_FOLDER, GPX_FOLDER, TCX_FOLDER
+from config import JSON_FILE, SQL_FILE, FOLDER_DICT
 from utils import make_activities_file
 
 COROS_URL_DICT = {
     "LOGIN_URL": "https://teamcnapi.coros.com/account/login",
     "DOWNLOAD_URL": "https://teamcnapi.coros.com/activity/detail/download",
     "ACTIVITY_LIST": "https://teamcnapi.coros.com/activity/query",
-}
-
-COROS_FOLDER_DICT = {
-    "gpx": GPX_FOLDER,
-    "fit": FIT_FOLDER,
-    "tcx": TCX_FOLDER,
 }
 
 COROS_TYPE_DICT = {
@@ -106,7 +100,7 @@ class Coros:
                 f"Sport type {sport_type} is not supported in {file_type} file. The activity will be ignored"
             )
             return
-        download_folder = COROS_FOLDER_DICT[file_type]
+        download_folder = FOLDER_DICT[file_type]
         download_url = (
             f"{COROS_URL_DICT.get('DOWNLOAD_URL')}?labelId={label_id}&sportType={sport_type}"
             f"&fileType={COROS_TYPE_DICT[file_type]}"
@@ -145,7 +139,7 @@ def get_downloaded_ids(folder):
 
 
 async def download_and_generate(account, password, only_run, file_type):
-    folder = COROS_FOLDER_DICT[file_type]
+    folder = FOLDER_DICT[file_type]
     downloaded_ids = get_downloaded_ids(folder)
     coros = Coros(account, password)
     await coros.init()

--- a/run_page/coros_sync.py
+++ b/run_page/coros_sync.py
@@ -14,7 +14,6 @@ COROS_URL_DICT = {
     "LOGIN_URL": "https://teamcnapi.coros.com/account/login",
     "DOWNLOAD_URL": "https://teamcnapi.coros.com/activity/detail/download",
     "ACTIVITY_LIST": "https://teamcnapi.coros.com/activity/query",
-    "ACTIVITY_URL": "",
 }
 
 COROS_FOLDER_DICT = {

--- a/run_page/coros_sync.py
+++ b/run_page/coros_sync.py
@@ -109,7 +109,7 @@ class Coros:
         download_folder = COROS_FOLDER_DICT[file_type]
         download_url = (
             f"{COROS_URL_DICT.get('DOWNLOAD_URL')}?labelId={label_id}&sportType={sport_type}"
-            "&fileType={COROS_TYPE_DICT[file_type]}"
+            f"&fileType={COROS_TYPE_DICT[file_type]}"
         )
         file_url = None
         try:

--- a/run_page/coros_sync.py
+++ b/run_page/coros_sync.py
@@ -7,14 +7,28 @@ import time
 import aiofiles
 import httpx
 
-from config import JSON_FILE, SQL_FILE, FIT_FOLDER
+from config import JSON_FILE, SQL_FILE, FIT_FOLDER, GPX_FOLDER, TCX_FOLDER
 from utils import make_activities_file
 
 COROS_URL_DICT = {
     "LOGIN_URL": "https://teamcnapi.coros.com/account/login",
     "DOWNLOAD_URL": "https://teamcnapi.coros.com/activity/detail/download",
     "ACTIVITY_LIST": "https://teamcnapi.coros.com/activity/query",
+    "ACTIVITY_URL": "",
 }
+
+COROS_FOLDER_DICT = {
+    "gpx": GPX_FOLDER,
+    "fit": FIT_FOLDER,
+    "tcx": TCX_FOLDER,
+}
+
+COROS_TYPE_DICT = {
+    "gpx": 1,
+    "fit": 4,
+    "tcx": 3,
+}
+
 
 TIME_OUT = httpx.Timeout(240.0, connect=360.0)
 
@@ -64,9 +78,9 @@ class Coros:
     async def init(self):
         await self.login()
 
-    async def fetch_activity_ids(self, only_run):
+    async def fetch_activity_ids_types(self, only_run):
         page_number = 1
-        all_activities_ids = []
+        all_activities_ids_types = []
 
         mode_list_str = "100,101,102,103" if only_run else ""
         while True:
@@ -78,17 +92,26 @@ class Coros:
                 break
             for activity in activities:
                 label_id = activity["labelId"]
+                sport_type = activity["sportType"]
                 if label_id is None:
                     continue
-                all_activities_ids.append(label_id)
+                all_activities_ids_types.append([label_id, sport_type])
 
             page_number += 1
 
-        return all_activities_ids
+        return all_activities_ids_types
 
-    async def download_activity(self, label_id):
-        download_folder = FIT_FOLDER
-        download_url = f"{COROS_URL_DICT.get('DOWNLOAD_URL')}?labelId={label_id}&sportType=100&fileType=4"
+    async def download_activity(self, label_id, sport_type, file_type):
+        if sport_type == 101 and file_type == "gpx":
+            print(
+                f"Sport type {sport_type} is not supported in {file_type} file. The activity will be ignored"
+            )
+            return
+        download_folder = COROS_FOLDER_DICT[file_type]
+        download_url = (
+            f"{COROS_URL_DICT.get('DOWNLOAD_URL')}?labelId={label_id}&sportType={sport_type}"
+            "&fileType={COROS_TYPE_DICT[file_type]}"
+        )
         file_url = None
         try:
             response = await self.req.post(download_url)
@@ -122,13 +145,15 @@ def get_downloaded_ids(folder):
     return [i.split(".")[0] for i in os.listdir(folder) if not i.startswith(".")]
 
 
-async def download_and_generate(account, password, only_run):
-    folder = FIT_FOLDER
+async def download_and_generate(account, password, only_run, file_type):
+    folder = COROS_FOLDER_DICT[file_type]
     downloaded_ids = get_downloaded_ids(folder)
     coros = Coros(account, password)
     await coros.init()
-
-    activity_ids = await coros.fetch_activity_ids(only_run=only_run)
+    activity_infos = await coros.fetch_activity_ids_types(only_run=only_run)
+    activity_ids = [i[0] for i in activity_infos]
+    activity_types = [i[1] for i in activity_infos]
+    activity_id_type_dict = dict(zip(activity_ids, activity_types))
     print("activity_ids: ", len(activity_ids))
     print("downloaded_ids: ", len(downloaded_ids))
     to_generate_coros_ids = list(set(activity_ids) - set(downloaded_ids))
@@ -137,11 +162,16 @@ async def download_and_generate(account, password, only_run):
     start_time = time.time()
     await gather_with_concurrency(
         10,
-        [coros.download_activity(label_d) for label_d in to_generate_coros_ids],
+        [
+            coros.download_activity(
+                label_id, activity_id_type_dict[label_id], file_type
+            )
+            for label_id in to_generate_coros_ids
+        ],
     )
     print(f"Download finished. Elapsed {time.time()-start_time} seconds")
     await coros.req.aclose()
-    make_activities_file(SQL_FILE, FIT_FOLDER, JSON_FILE, "fit")
+    make_activities_file(SQL_FILE, folder, JSON_FILE, file_type)
 
 
 async def gather_with_concurrency(n, tasks):
@@ -166,11 +196,32 @@ if __name__ == "__main__":
         action="store_true",
         help="if is only for running",
     )
+
+    parser.add_argument(
+        "--tcx",
+        dest="download_file_type",
+        action="store_const",
+        const="tcx",
+        default="fit",
+        help="to download personal documents or ebook",
+    )
+    parser.add_argument(
+        "--gpx",
+        dest="download_file_type",
+        action="store_const",
+        const="gpx",
+        default="fit",
+        help="to download personal documents or ebook",
+    )
     options = parser.parse_args()
 
     account = options.account
     password = options.password
     is_only_running = options.only_run
+    file_type = options.download_file_type
+    file_type = file_type if file_type in ["gpx", "tcx", "fit"] else "fit"
     encrypted_pwd = hashlib.md5(password.encode()).hexdigest()
 
-    asyncio.run(download_and_generate(account, encrypted_pwd, is_only_running))
+    asyncio.run(
+        download_and_generate(account, encrypted_pwd, is_only_running, file_type)
+    )


### PR DESCRIPTION
1. Add support for gpx and tcx file format.
2. Fix: Default values are incompatible due to varying type values across sport types.
```python
download_url = f"{COROS_URL_DICT.get('DOWNLOAD_URL')}?labelId={label_id}&sportType=100&fileType=4"
```