### PR TITLE
refactor: optimize mouse-over effect for year images

### DIFF
--- a/src/components/YearStat/index.tsx
+++ b/src/components/YearStat/index.tsx
@@ -59,12 +59,8 @@ const YearStat = ({
     0
   );
   return (
-    <div
-      className="cursor-pointer"
-      onClick={() => onClick(year)}
-      {...eventHandlers}
-    >
-      <section>
+    <div className="cursor-pointer" onClick={() => onClick(year)}>
+      <section {...eventHandlers}>
         <Stat value={year} description=" Journey" />
         <Stat value={runs.length} description=" Runs" />
         <Stat value={sumDistance} description=" KM" />

--- a/src/hooks/useHover.ts
+++ b/src/hooks/useHover.ts
@@ -1,17 +1,19 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
 type HoverHook = [boolean, { onMouseOver: () => void; onMouseOut: () => void }];
 
 const useHover = (): HoverHook => {
   const [hovered, setHovered] = useState(false);
-  const [timer, setTimer] = useState<number>();
+  const timerRef = useRef<number>();
 
   const eventHandlers = {
     onMouseOver() {
-      setTimer(setTimeout(() => setHovered(true), 500)); // 500ms delay
+      // Clear the previous timer if it exists to handle rapid mouse movements
+      clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => setHovered(true), 1000);
     },
     onMouseOut() {
-      clearTimeout(timer);
+      clearTimeout(timerRef.current);
       setHovered(false);
     },
   };


### PR DESCRIPTION
- Change the binding element of the mouseover area to avoid `hr`
- Use `timerRef` to store the id of the `setTimeout` so that rendering is not repeatedly triggered when the mouse moves in and out quickly.
- Change the trigger time of svg to 1000 ms.