### PR TITLE
Update run_data_sync.yml

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -28,7 +28,7 @@ env:
   RUN_TYPE: pass # support strava/nike/garmin/coros/garmin_cn/garmin_sync_cn_global/keep/only_gpx/only_fit/nike_to_strava/strava_to_garmin/tcx_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/oppo/db_updater, Please change the 'pass' it to your own
   ATHLETE: yihong0618
   TITLE: Yihong0618 Running
-  MIN_GRID_DISTANCE: 10 # change min distance here
+  MIN_GRID_DISTANCE: "10" # change min distance here
   TITLE_GRID: Over 10km Runs # also here
 
   # IGNORE_BEFORE_SAVING: True # if you want to ignore some data before saving, set this to True


### PR DESCRIPTION
MIN_GRID_DISTANCE: "10" # change min distance here 10增加双引号，避免部分情况可能会出现Error: Process completed with exit code 2.的错误。 The job failed because the script gen_svg.py received an environment variable $MIN_GRID_DISTANCE that was not properly set as a float value. This resulted in the error: