### PR TITLE
fix: Prevent add_summary_info from processing non-GPX files (#971)

### DIFF
--- a/run_page/garmin_sync.py
+++ b/run_page/garmin_sync.py
@@ -272,7 +272,7 @@ async def download_garmin_data(
     folder = FOLDER_DICT.get(file_type, "gpx")
     try:
         file_data = await client.download_activity(activity_id, file_type=file_type)
-        if summary_infos is not None:
+        if summary_infos is not None and file_type == "gpx":
             file_data = add_summary_info(file_data, summary_infos.get(activity_id))
         file_path = os.path.join(folder, f"{activity_id}.{file_type}")
         need_unzip = False


### PR DESCRIPTION
Closes #971

Fixed an issue where the add_summary_info function would cause an XML error when parsing non-GPX files (like .fit). This was resolved by adding and file_type == "gpx" to the call condition.