### PR TITLE
fix: strava_sync forced to only_run

### DIFF
--- a/run_page/strava_sync.py
+++ b/run_page/strava_sync.py
@@ -10,7 +10,7 @@ def run_strava_sync(
     client_id,
     client_secret,
     refresh_token,
-    sync_types: list = ["running"],
+    sync_types: list = None,
     only_run=False,
 ):
     generator = Generator(SQL_FILE)


### PR DESCRIPTION
The `sync_types` parameter was introduced in PR #923, but its default value causes `only_run` to be set to true.
```
def run_strava_sync(
    client_id,
    client_secret,
    refresh_token,
    sync_types: list = ["running"],
    only_run=False,
):
    generator = Generator(SQL_FILE)
    generator.set_strava_config(client_id, client_secret, refresh_token)
    # judge sync types is only running or not
->    if not only_run and len(sync_types) == 1 and sync_types[0] == "running":
        only_run = True

```
This would cause all scripts that do not pass this parameter, including `strava_sync.py` itself, to only sync the Run type.
fix https://github.com/ben-29/workouts_page/issues/50