### PR TITLE
Fix strava sync Error

### DIFF
--- a/run_page/strava_sync.py
+++ b/run_page/strava_sync.py
@@ -10,7 +10,7 @@ def run_strava_sync(
     client_id,
     client_secret,
     refresh_token,
-    sync_types: list = ["running"],
+    sync_types: list = None,
     only_run=False,
 ):
     generator = Generator(SQL_FILE)

--- a/run_page/strava_sync.py
+++ b/run_page/strava_sync.py
@@ -10,7 +10,7 @@ def run_strava_sync(
     client_id,
     client_secret,
     refresh_token,
-    sync_types: list = None,
+    sync_types: list = [],
     only_run=False,
 ):
     generator = Generator(SQL_FILE)


### PR DESCRIPTION
The last PR introduced a bug; change the default to an empty list instead of `None` to prevent errors caused by `len(None)`.