### PR TITLE
fix naming inconsistency between activity and mapbox data

### DIFF
--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -6,9 +6,11 @@ import activities from '@/static/activities.json';
 const standardizeCountryName = (country: string): string => {
   if (country.includes('美利坚合众国')) {
     return '美国';
-  } if (country.includes('英国')) {
+  }
+  if (country.includes('英国')) {
     return '英国';
-  } if (country.includes('印度尼西亚')) {
+  }
+  if (country.includes('印度尼西亚')) {
     return '印度尼西亚';
   } else {
     return country;

--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -4,13 +4,14 @@ import activities from '@/static/activities.json';
 
 // standardize country names for consistency between mapbox and activities data
 const standardizeCountryName = (country: string): string => {
-  switch (country) {
-    case '英国 / 英國':
-      return '英国';
-    case '美利坚合众国/美利堅合眾國':
-      return '美国';
-    default:
-      return country;
+  if (country.includes('美利坚合众国')) {
+    return '美国';
+  } if (country.includes('英国')) {
+    return '英国';
+  } if (country.includes('印度尼西亚')) {
+    return '印度尼西亚';
+  } else {
+    return country;
   }
 };
 


### PR DESCRIPTION
Revise country name conversion into a more flexible way. Fix Indonesia nameing inconsistency.