### PR TITLE
fix: Update Index component to use siteUrl for homepage link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,7 +28,7 @@ import {
 import { useTheme, useThemeChangeCounter } from '@/hooks/useTheme';
 
 const Index = () => {
-  const { siteTitle } = useSiteMetadata();
+  const { siteTitle, siteUrl } = useSiteMetadata();
   const { activities, thisYear } = useActivities();
   const themeChangeCounter = useThemeChangeCounter(); // Add theme change listener
   const [year, setYear] = useState(thisYear);
@@ -362,7 +362,7 @@ const Index = () => {
       </Helmet>
       <div className="w-full lg:w-1/3">
         <h1 className="my-12 mt-6 text-5xl font-extrabold italic">
-          <a href="/">{siteTitle}</a>
+          <a href={siteUrl}>{siteTitle}</a>
         </h1>
         {(viewState.zoom ?? 0) <= 3 && IS_CHINESE ? (
           <LocationStat


### PR DESCRIPTION
This PR updates the `Index` component to use the `siteUrl` from the site metadata instead of a static "/" for the homepage link. This improves maintainability by ensuring the link is dynamically pulled from the site configuration.