### PR TITLE
fix: Codoon export KeyError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,3 @@ route.png
 route.svg
 
 .env
-
-/FIT_OUT
-/GPX_OUT
-/TCX_OUT

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ route.png
 route.svg
 
 .env
+
+/FIT_OUT
+/GPX_OUT
+/TCX_OUT

--- a/run_page/codoon_sync.py
+++ b/run_page/codoon_sync.py
@@ -175,7 +175,8 @@ def tcx_output(fit_array, run_data):
     #       DistanceMeters
     activity_lap.append(formated_input(run_data, "total_length", "DistanceMeters"))
     #       Calories
-    activity_lap.append(formated_input(run_data, "total_calories", "Calories"))
+    if "total_calories" in run_data:
+        activity_lap.append(formated_input(run_data, "total_calories", "Calories"))
 
     # Track
     track = ET.Element("Track")


### PR DESCRIPTION
报错原因：早期的咕咚运动记录没有“总卡路里消耗”信息。