### PR TITLE
fix: Keep export tcx format timestamp error

### DIFF
--- a/run_page/keep_sync.py
+++ b/run_page/keep_sync.py
@@ -331,8 +331,7 @@ def parse_points_to_tcx(run_data, run_points_data, sport_type):
 
     # note that the timestamp of a point is decisecond(分秒)
     fit_start_time = datetime.fromtimestamp(
-        run_data.get("startTime") / 1000,
-        tz=timezone.utc
+        run_data.get("startTime") / 1000, tz=timezone.utc
     ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Root node
@@ -384,8 +383,7 @@ def parse_points_to_tcx(run_data, run_points_data, sport_type):
         # Time
         # note that the timestamp of a point is decisecond(分秒)
         time_stamp = datetime.fromtimestamp(
-            (run_data.get("startTime") + point.get("timestamp")) / 1000,
-            tz=timezone.utc
+            (run_data.get("startTime") + point.get("timestamp")) / 1000, tz=timezone.utc
         ).strftime("%Y-%m-%dT%H:%M:%SZ")
         time_label = ET.Element("Time")
         time_label.text = time_stamp


### PR DESCRIPTION
修复了 keep_sync.py 在导出 tcx 文件时，时间戳异常的问题。
具体表现是 <Trackpoint>  中的 <Time> 标签会从 1970-01-01 开始，而不是真正的运动开始时间。