### PR TITLE
fix: fix some bugs

### DIFF
--- a/run_page/codoon_sync.py
+++ b/run_page/codoon_sync.py
@@ -285,7 +285,8 @@ def tcx_job(run_data):
         for own_step in own_steps:
             [single_time, single_step] = own_step[0:2]
             # firstly, convert 2025-09-16 20:08:00 to 2025-09-16T20:08:00
-            single_time = single_time.replace(" ", "T")
+            # also,    convert 2015-09-16+20:08:00 to 2015-09-16T20:08:00
+            single_time = single_time.replace(" ", "T").replace("+", "T")
             # move to UTC
             utc = adjust_time_to_utc(to_date(single_time), str(get_localzone()))
             time_stamp = utc.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -296,7 +297,7 @@ def tcx_job(run_data):
             fit_steps[unix_time] = int(single_step)
 
     # get single track point
-    if len(own_points) > 0:
+    if own_points:
         for point in own_points:
             time_stamp = point.get("time_stamp")
             latitude = point.get("latitude")


### PR DESCRIPTION
修复了`codoon_sync.py`中的2个bug：

1. 时间戳格式不匹配

2015年及以前的数据，时间戳格式为`2015-09-16+20:08:00`，而非目前采用的`2025-09-16 20:08:00`。

因此增加了一层格式转换检查。

2. NoneType Error

`own_points`初始化是`None`，而非`[]`。

因此更改了检查空数据的判据。