### PR TITLE
feat: add average distance in the summary

### DIFF
--- a/src/components/ActivityList/index.tsx
+++ b/src/components/ActivityList/index.tsx
@@ -212,6 +212,10 @@ const ActivityCardInner: React.FC<ActivityCardProps> = ({
                   <strong>{ACTIVITY_TOTAL.MAX_SPEED_TITLE}:</strong>{' '}
                   {formatPace(summary.maxSpeed)}
                 </p>
+                <p>
+                  <strong>{ACTIVITY_TOTAL.AVERAGE_DISTANCE_TITLE}:</strong>{' '}
+                  {(summary.totalDistance / summary.count).toFixed(2)} km
+                </p>
               </>
             )}
             {['month', 'week', 'year'].includes(interval) && (

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -88,6 +88,7 @@ const MAX_SPEED_TITLE = IS_CHINESE ? '最快速度' : 'Max Speed';
 const TOTAL_TIME_TITLE = IS_CHINESE ? '总时间' : 'Total Time';
 const AVERAGE_SPEED_TITLE = IS_CHINESE ? '平均速度' : 'Average Speed';
 const TOTAL_DISTANCE_TITLE = IS_CHINESE ? '总距离' : 'Total Distance';
+const AVERAGE_DISTANCE_TITLE = IS_CHINESE ? '平均距离' : 'Average Distance';
 const TOTAL_ELEVATION_GAIN_TITLE = IS_CHINESE
   ? '总海拔爬升'
   : 'Total Elevation Gain';
@@ -129,6 +130,7 @@ const ACTIVITY_TOTAL = {
   TOTAL_TIME_TITLE,
   AVERAGE_SPEED_TITLE,
   TOTAL_DISTANCE_TITLE,
+  AVERAGE_DISTANCE_TITLE,
   TOTAL_ELEVATION_GAIN_TITLE,
   AVERAGE_HEART_RATE_TITLE,
   YEARLY_TITLE,


### PR DESCRIPTION
- add average distance in the summary page

<img width="1583" height="721" alt="Screenshot 2025-10-17 at 10 46 58 PM" src="https://github.com/user-attachments/assets/a2f1b015-2625-43a0-90f3-65f1f7f42fcf" />
