### PR TITLE
fix: Keep export heartrate timestamp error

### DIFF
--- a/run_page/keep_sync.py
+++ b/run_page/keep_sync.py
@@ -7,7 +7,6 @@ import zlib
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 from xml.dom import minidom
-
 import eviltransform
 import gpxpy
 import polyline
@@ -448,7 +447,11 @@ def find_nearest_hr(
         target_time = target_time = target_time - start_time // 100
 
     for item in hr_data_list:
-        timestamp = item["timestamp"]
+        timestamp = item.get("timestamp")
+
+        if not timestamp:
+            continue
+
         difference = abs(timestamp - target_time)
 
         if difference <= threshold and difference < min_difference:


### PR DESCRIPTION
修复bug：在解析来自 Keep 的运动记录时，部分心率数据点没有时间戳，导致该记录解析失败。