### PR TITLE
Fix map theme colors not updating on theme change

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,11 +25,12 @@ import {
   titleForShow,
   RunIds,
 } from '@/utils/utils';
-import { useTheme } from '@/hooks/useTheme';
+import { useTheme, useThemeChangeCounter } from '@/hooks/useTheme';
 
 const Index = () => {
   const { siteTitle, siteUrl } = useSiteMetadata();
   const { activities, thisYear } = useActivities();
+  const themeChangeCounter = useThemeChangeCounter();
   const [year, setYear] = useState(thisYear);
   const [runIndex, setRunIndex] = useState(-1);
   const [title, setTitle] = useState('');
@@ -94,7 +95,7 @@ const Index = () => {
 
   const geoData = useMemo(() => {
     return geoJsonForRuns(runs);
-  }, [runs]);
+  }, [runs, themeChangeCounter]);
 
   // for auto zoom
   const bounds = useMemo(() => {


### PR DESCRIPTION
## Summary
- Fixed map theme colors not updating when theme is toggled
- Added `themeChangeCounter` to `geoData` useMemo dependencies to trigger re-calculation when theme changes

## Details
The `geoData` useMemo was missing `themeChangeCounter` in its dependency array, causing the map colors to not update when switching themes. This fix adds the `themeChangeCounter` dependency to trigger re-calculation of geoData when the theme changes, ensuring map polyline colors stay in sync with the current theme.

## Test plan
- [x] Toggle between light and dark themes
- [x] Verify map colors update immediately to match the new theme
- [x] Confirm no console errors or warnings