### PR TITLE
Fix color mismatch for Strava imported non-run activities

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -251,12 +251,16 @@ const colorForRun = (run: Activity): string => {
       return dynamicRunColor;
     }
     case 'cycling':
+    case 'Ride': // For Strava
       return CYCLING_COLOR;
     case 'hiking':
+    case 'Hike': // For Strava
       return HIKING_COLOR;
     case 'walking':
+    case 'Walk': // For Strava
       return WALKING_COLOR;
     case 'swimming':
+    case 'Swim': // For Strava
       return SWIMMING_COLOR;
     default:
       return MAIN_COLOR;


### PR DESCRIPTION
## 背景 / Background

**中文：**  
在 [Discussion #1066](https://github.com/yihong0618/running_page/discussions/1066) 中提到，从 Strava 导入的 Ride、Hike、Walk 等活动因为类型名称不匹配（项目代码中使用的是 `cycling` / `hiking` / `walking`），会导致这些活动的轨迹颜色被 default 到 `MAIN_COLOR`，而不是对应的专用颜色。

**English:**  
As mentioned in [Discussion #1066](https://github.com/yihong0618/running_page/discussions/1066), activities imported from Strava such as Ride, Hike, Walk are not correctly colored because the type names don't match the project's keywords (`cycling` / `hiking` / `walking`). As a result, these activities default to `MAIN_COLOR` instead of their specific colors.

## 改动说明 / Changes

**中文：**  
- 在 `colorForRun` 函数中增加对 Strava 原生类型（`Ride`、`Hike`、`Walk`、`Swim` 等）的支持  
- 保持原有 `cycling` / `hiking` 等写法的完全兼容性  
- 不影响任何已有的自定义数据

**English:**  
- Add support for Strava's native activity types (`Ride`, `Hike`, `Walk`, `Swim`, etc.) in the `colorForRun` function  
- Maintain full backward compatibility with existing lowercase keywords (`cycling`, `hiking`, etc.)  
- No impact on custom user data

## 验证方式 / Verification

**中文：**  
我用自己的 Strava 数据进行了验证：导入活动的记录后，页面上这些活动的轨迹颜色已正确显示为对应的颜色（而非默认 MAIN_COLOR）。

**English:**  
I have verified with my own Strava data: after importing activities, the track colors on the page are now correctly displayed using their corresponding colors (instead of default to MAIN_COLOR).

<img width="585" height="464" alt="my_results" src="https://github.com/user-attachments/assets/7ab852d6-ff00-417c-8cd2-832036a923da" />


感谢 review！ / Thanks for the review!