### PR TITLE
fix: make mapboxAccessToken conditional based on MAP_TILE_VENDOR

### DIFF
--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -92,6 +92,17 @@ const RunMap = ({
     [currentMapTheme]
   );
 
+  // Mapbox GL JS requires a token even when using other vendors
+  // Use actual MAPBOX_TOKEN when vendor is 'mapbox', otherwise use a dummy token
+  const mapboxAccessToken = useMemo(() => {
+    if (MAP_TILE_VENDOR === 'mapbox') {
+      return MAPBOX_TOKEN;
+    }
+    // Use a dummy token for other vendors (Mapbox GL JS still requires a token)
+    // This is a valid format but won't be used for actual mapbox requests
+    return 'pk.eyJ1IjoidW5rbm93biIsImEiOiJjbGZqY2N0d3EwMGNsM3BwN2N4d2N4d2N4In0.unknown';
+  }, []);
+
   // Update map when theme changes
   useEffect(() => {
     if (mapRef.current) {
@@ -370,7 +381,7 @@ const RunMap = ({
       mapStyle={mapStyle}
       ref={mapRefCallback}
       cooperativeGestures={isTouchDevice()}
-      mapboxAccessToken={MAPBOX_TOKEN}
+      mapboxAccessToken={mapboxAccessToken}
     >
       <RunMapButtons changeYear={changeYear} thisYear={thisYear} />
       <Source id="data" type="geojson" data={combinedGeoData}>


### PR DESCRIPTION
Fixes #1030

## Problem
Mapbox GL JS still requires a mapbox token even when using other vendors like maptiler or stadiamaps. This causes issues when users want to use alternative map tile vendors.

## Solution
Made the `mapboxAccessToken` conditional based on `MAP_TILE_VENDOR`:
- When vendor is `mapbox`, use the actual `MAPBOX_TOKEN`
- When using other vendors (maptiler, stadiamaps), use a dummy token since Mapbox GL JS still requires a token but won't use it for actual requests

## Changes
- Added conditional logic in `RunMap` component to set `mapboxAccessToken` based on vendor
- This allows users to use maptiler or stadiamaps without requiring a valid mapbox token

## Testing
- Tested that the map still works correctly when using mapbox vendor
- The dummy token format is valid and won't cause errors with Mapbox GL JS