### PR TITLE
fix: ensure theme color updates correctly on total map view

### DIFF
--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -135,7 +135,7 @@ const RunMap = ({
       // Use once to automatically remove the listener after it fires
       map.once('style.load', handleStyleLoad);
     }
-  }, [mapStyle]); // Keep only mapStyle in dependency to prevent excessive re-renders
+  }, [mapStyle, lights]); // Include lights to ensure layer visibility updates correctly when theme changes
 
   useEffect(() => {
     if (mapRef.current) {


### PR DESCRIPTION
Fixes #1004

## Problem
Theme color on map not changing when viewing total map. When users switch themes while viewing the total map, the map style doesn't update correctly.

## Solution
Added `lights` to the dependency array of the useEffect that handles map style updates. This ensures that when the theme changes, both the map style and layer visibility are updated correctly.

## Changes
- Added `lights` to the dependency array in the map style update useEffect
- This ensures proper theme updates on total map view

## Testing
- Verified that theme changes now work correctly on total map view
- Map style and layer visibility update properly when theme changes