### PR TITLE
Skip existing TCX exports during Codoon reruns

### DIFF
--- a/run_page/codoon_sync.py
+++ b/run_page/codoon_sync.py
@@ -551,13 +551,16 @@ class Codoon:
         return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S")
 
     def parse_raw_data_to_namedtuple(
-        self, run_data, old_gpx_ids, with_gpx=False, with_tcx=False
+        self, run_data, old_gpx_ids, old_tcx_ids=None, with_gpx=False, with_tcx=False
     ):
         run_data = run_data["data"]
         log_id = run_data["id"]
 
         if with_tcx:
-            tcx_job(run_data)  # TCX part
+            if old_tcx_ids is not None and str(log_id) in old_tcx_ids:
+                print(f"skip existing tcx for codoon id {log_id}")
+            else:
+                tcx_job(run_data)  # TCX part
 
         start_time = run_data.get("start_time")
         if not start_time:
@@ -632,15 +635,21 @@ class Codoon:
     def get_old_tracks(self, old_ids, with_gpx=False, with_tcx=False):
         run_records = self.get_runs_records()
 
-        old_gpx_ids = os.listdir(GPX_FOLDER)
-        old_gpx_ids = [i.split(".")[0] for i in old_gpx_ids if not i.startswith(".")]
+        old_gpx_ids = os.listdir(GPX_FOLDER) if os.path.isdir(GPX_FOLDER) else []
+        old_gpx_ids = {i.split(".")[0] for i in old_gpx_ids if not i.startswith(".")}
+        old_tcx_ids = set()
+        if with_tcx:
+            old_tcx_files = os.listdir(TCX_FOLDER) if os.path.isdir(TCX_FOLDER) else []
+            old_tcx_ids = {
+                i.split(".")[0] for i in old_tcx_files if not i.startswith(".")
+            }
         new_run_routes = [i for i in run_records if str(i["log_id"]) not in old_ids]
         tracks = []
         for i in new_run_routes:
             run_data = self.get_single_run_record(i["route_id"])
             run_data["data"]["id"] = i["log_id"]
             track = self.parse_raw_data_to_namedtuple(
-                run_data, old_gpx_ids, with_gpx, with_tcx
+                run_data, old_gpx_ids, old_tcx_ids, with_gpx, with_tcx
             )
             if track:
                 tracks.append(track)


### PR DESCRIPTION
## What changed

This PR updates `codoon_sync.py` to skip TCX generation when the target `.tcx` file already exists in `TCX_OUT`.

### Changes
- Load existing TCX file IDs before processing activities
- Check for an existing TCX file before calling `tcx_job`
- Print a skip message when a TCX file is already present

## Why

Codoon sync reruns should not regenerate TCX exports that have already been written. Skipping existing files makes reruns faster and avoids unnecessary overwrites.

## Testing

- Ran:
  `python -m py_compile running_page/run_page/codoon_sync.py`

## Impact

- Existing TCX files are preserved on rerun
- Only missing TCX files are generated
- Reruns are more efficient
