### PR TITLE
fix: disable pointer events for indoor activity rectangles

### DIFF
--- a/run_page/gpxtrackposter/github_drawer.py
+++ b/run_page/gpxtrackposter/github_drawer.py
@@ -203,6 +203,7 @@ class GithubDrawer(TracksDrawer):
                                     (rect_x, rect_y),
                                     dom,
                                     fill="url(#indoor-stripe)",
+                                    style="pointer-events: none;",
                                 )
                             )
                     github_rect_day += datetime.timedelta(1)


### PR DESCRIPTION
previous indoor activity will not show tips, below is fixed result.
<img width="1062" height="377" alt="image" src="https://github.com/user-attachments/assets/dbca5347-f5bb-4b49-9c1c-2cc066b1ba9f" />
