### PR TITLE
docs: add note for Strava API update

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -763,6 +763,9 @@ python run_page/nike_sync.py eyJhbGciThiMTItNGIw******
 
 <br>
 
+> [!NOTE]
+> Strava 在 2026 年 6 月更新了 Developer Program。如果你使用 Strava 作为数据源，或者先把其它平台的数据上传到 Strava 再同步，请先在 [Strava API settings dashboard](https://www.strava.com/settings/api) 检查自己的 app tier。Standard Tier 开发者需要拥有 Strava 订阅才能访问 API；已有 Standard Tier 开发者会从 2026 年 6 月 30 日开始受到影响。详情见 [Strava 官方公告](https://communityhub.strava.com/insider-journal-9/an-update-to-our-developer-program-13428)。
+
 1. 注册/登陆 [Strava](https://www.strava.com/) 账号
 2. 登陆成功后打开 [Strava Developers](http://developers.strava.com) -> [Create & Manage Your App](https://strava.com/settings/api)
 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,9 @@ python run_page/nike_sync.py eyJhbGciThiMTItNGIw******
 
 <br>
 
+> [!NOTE]
+> Strava updated its Developer Program in June 2026. If you use Strava as the data source, or upload activities to Strava before syncing, check your app tier in the [Strava API settings dashboard](https://www.strava.com/settings/api). Standard Tier developers need a Strava subscription to access the API; existing Standard Tier developers are affected from June 30, 2026. See [Strava's announcement](https://communityhub.strava.com/insider-journal-9/an-update-to-our-developer-program-13428) for details.
+
 1. Sign in/Sign up [Strava](https://www.strava.com/) account
 2. Open after successful Signin [Strava Developers](http://developers.strava.com) -> [Create & Manage Your App](https://strava.com/settings/api)
 3. Create `My API Application`: Enter the following information


### PR DESCRIPTION
## What

Add a README note about Strava's June 2026 Developer Program update and its impact on users who sync data through Strava API.

## Why

Strava announced new developer tiers and subscription requirements:

- Starting June 1, 2026, new Standard Tier developers need a Strava subscription to access the API.
- Starting June 30, 2026, existing Standard Tier developers also need a Strava subscription.

This project relies on Strava API credentials when `RUN_TYPE=strava` or when uploading other data sources to Strava, so users following the README should be aware of the new requirement.

References:
- https://communityhub.strava.com/insider-journal-9/an-update-to-our-developer-program-13428
- https://github.com/yihong0618/running_page/discussions/1126

## Notes

This PR only updates documentation. No code behavior is changed.