### PR TITLE
fix: upload Garmin treadmill activities to Strava via FIT

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -198,12 +198,12 @@ jobs:
       - name: Run sync Garmin-cn to Strava(Run with Garmin data backup in Strava)
         if: env.RUN_TYPE == 'garmin_to_strava_cn'
         run: |
-          python run_page/garmin_to_strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_SECRET_STRING_CN }}  --is-cn
+          python run_page/garmin_to_strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_SECRET_STRING_CN }}  --is-cn --fit
 
       - name: Run sync Garmin to Strava(Run with Garmin data backup in Strava)
         if: env.RUN_TYPE == 'garmin_to_strava'
         run: |
-          python run_page/garmin_to_strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }}
+          python run_page/garmin_to_strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}  ${{ secrets.GARMIN_EMAIL }} ${{ secrets.GARMIN_PASSWORD }} --fit
 
       - name: Run sync Tulipsport script
         if: env.RUN_TYPE == 'tulipsport'

--- a/run_page/garmin_to_strava_sync.py
+++ b/run_page/garmin_to_strava_sync.py
@@ -28,14 +28,29 @@ if __name__ == "__main__":
         action="store_true",
         help="if garmin account is cn",
     )
-    parser.add_argument(
+    file_type_group = parser.add_mutually_exclusive_group()
+    file_type_group.add_argument(
+        "--gpx",
+        dest="download_file_type",
+        action="store_const",
+        const="gpx",
+        help="download GPX files (not recommended for treadmill activities)",
+    )
+    file_type_group.add_argument(
         "--tcx",
         dest="download_file_type",
         action="store_const",
         const="tcx",
-        default="gpx",
-        help="to download personal documents or ebook",
+        help="download TCX files",
     )
+    file_type_group.add_argument(
+        "--fit",
+        dest="download_file_type",
+        action="store_const",
+        const="fit",
+        help="download FIT files (recommended for Strava uploads)",
+    )
+    parser.set_defaults(download_file_type="fit")
     options = parser.parse_args()
     strava_client = make_strava_client(
         options.strava_client_id,


### PR DESCRIPTION
## Problem
Garmin treadmill activities can produce GPX files without GPS track points. The existing Garmin-to-Strava workflow downloads GPX by default, so Strava may reject or omit these activities while GPS-based outdoor runs continue to work.

## Fix
- Use FIT as the default file format for Garmin-to-Strava uploads.
- Keep GPX and TCX available as explicit compatibility options.
- Pass `--fit` explicitly in both Garmin-to-Strava workflow paths.

FIT preserves the activity data needed by Strava for treadmill activities and also works for outdoor runs.

## Validation
- Black check passed
- Ruff check passed
- Prettier check, ESLint, and Vite build passed
- Python compilation and workflow YAML parsing passed