### PR TITLE
fix: add back Summary page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,23 +22,7 @@ export default function App() {
   return (
     <LocaleProvider>
       <ErrorBoundary>
-        <Suspense
-          fallback={
-            <div
-              className="flex min-h-screen items-center justify-center"
-              style={{ backgroundColor: 'var(--color-bg, #0d1117)' }}
-            >
-              <div
-                style={{
-                  color: 'var(--color-muted, #8b949e)',
-                  fontSize: '0.875rem',
-                }}
-              >
-                Loading...
-              </div>
-            </div>
-          }
-        >
+        <Suspense>
           <ThemeComponent />
         </Suspense>
       </ErrorBoundary>

--- a/src/themes/classic/index.tsx
+++ b/src/themes/classic/index.tsx
@@ -1,15 +1,19 @@
 import './styles/index.css';
-import { Suspense } from 'react';
+import { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import Index from './pages/index';
+
+const Summary = lazy(() => import('./pages/summary'));
 
 export default function ClassicTheme() {
   return (
     <HelmetProvider>
       <BrowserRouter>
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense>
           <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/summary" element={<Summary />} />
             <Route path="*" element={<Index />} />
           </Routes>
         </Suspense>

--- a/src/themes/classic/pages/summary.tsx
+++ b/src/themes/classic/pages/summary.tsx
@@ -1,0 +1,7 @@
+import ActivityList from '../components/ActivityList';
+
+const SummaryPage = () => {
+  return <ActivityList />;
+};
+
+export default SummaryPage;


### PR DESCRIPTION
- added back the missing summary router, which is a regression due to https://github.com/yihong0618/running_page/pull/1123
- removed the `fallback` for `Suspense`, which caused the UI flickering. 
  - we might want to have more sophisticated loading skeleton, which deserves its own pr  