### PR TITLE
feat: add Strava web sync via JWT session

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   # please change to your own config.
-  RUN_TYPE: pass # support strava/nike/garmin/coros/garmin_cn/garmin_sync_cn_global/keep/only_gpx/only_fit/nike_to_strava/strava_to_garmin/tcx_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/oppo/intervals_icu/db_updater, Please change the 'pass' it to your own
+  RUN_TYPE: pass # support strava_web/strava/nike/garmin/coros/garmin_cn/garmin_sync_cn_global/keep/only_gpx/only_fit/nike_to_strava/strava_to_garmin/tcx_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/oppo/intervals_icu/db_updater, Please change the 'pass' it to your own
   ATHLETE: yihong0618
   TITLE: Yihong0618 Running
   MIN_GRID_DISTANCE: 10 # change min distance here
@@ -144,6 +144,13 @@ jobs:
         run: |
           python run_page/strava_sync.py ${{ secrets.STRAVA_CLIENT_ID }} ${{ secrets.STRAVA_CLIENT_SECRET }} ${{ secrets.STRAVA_CLIENT_REFRESH_TOKEN }}
         # If you only want to sync 'type running' add args --only-run, default script is to sync all data (rides and runs).
+
+      # Strava web sync: uses the strava_remember_token JWT (web endpoints) instead of the
+      # OAuth2 API, for when the API application is inactive. --days controls lookback.
+      - name: Run sync Strava web script
+        if: env.RUN_TYPE == 'strava_web'
+        run: |
+          python run_page/strava_web_sync.py "${{ secrets.STRAVA_JWT }}" --days "${{ vars.STRAVA_WEB_DAYS || '7' }}"
 
       # for garmin if you want generate 'tcx' you can add --tcx command in the args.
       - name: Run sync Garmin script

--- a/README-CN.md
+++ b/README-CN.md
@@ -205,6 +205,32 @@ pnpm develop
 
 访问 <http://localhost:5173/> 查看
 
+## Strava 网页同步（Web 同步）
+
+> 当 Strava API 应用处于 `inactive` 状态（OAuth2 请求全部返回 403）时，可以用网页端接口同步数据。
+
+```bash
+# 本地同步（拉最近 7 天）
+python run_page/strava_web_sync.py <JWT> --days 7
+
+# 只同步跑步
+python run_page/strava_web_sync.py <JWT> --days 7 --only-run
+```
+
+**JWT 获取方式**：
+
+1. 浏览器登录 [strava.com](https://www.strava.com)
+2. F12 打开开发者工具 → Application → Cookies → `https://www.strava.com`
+3. 复制 `strava_remember_token` 的 Value（一长串 `eyJ...` 的 JWT）
+
+**CI 接入**：
+
+- 在 workflow 的 `RUN_TYPE` 中选择 `strava_web`
+- 配置 GitHub Secret：`STRAVA_JWT`（JWT 值）
+- 可选 Variable：`STRAVA_WEB_DAYS`（默认 7）
+
+> ⚠️ JWT 约 30 天过期，过期后需重新从浏览器复制更新 `STRAVA_JWT`。
+
 ## TUI（终端界面）
 
 你可以在终端中使用内置的 Textual TUI 浏览运动数据。

--- a/README.md
+++ b/README.md
@@ -195,6 +195,32 @@ pnpm develop
 
 Open your browser and visit <http://localhost:5173/>
 
+## Strava Web Sync
+
+> For when your Strava API application is `inactive` (all OAuth2 requests return 403), you can sync activities through Strava's web endpoints instead.
+
+```bash
+# Sync locally (last 7 days by default)
+python run_page/strava_web_sync.py <JWT> --days 7
+
+# Runs only
+python run_page/strava_web_sync.py <JWT> --days 7 --only-run
+```
+
+**Getting the JWT:**
+
+1. Log in to [strava.com](https://www.strava.com) in your browser
+2. DevTools (F12) → Application → Cookies → `https://www.strava.com`
+3. Copy the value of `strava_remember_token` (a long `eyJ...` JWT)
+
+**CI setup:**
+
+- Set `RUN_TYPE` to `strava_web` in the workflow
+- Add GitHub Secret `STRAVA_JWT` (the JWT value)
+- Optional Variable `STRAVA_WEB_DAYS` (default: 7)
+
+> ⚠️ The JWT expires in ~30 days. Refresh `STRAVA_JWT` by re-copying it from the browser when it does.
+
 ## TUI (Terminal UI)
 
 You can browse your activities in the terminal using the built-in Textual TUI.

--- a/run_page/strava_web_sync.py
+++ b/run_page/strava_web_sync.py
@@ -18,14 +18,18 @@ Usage:
 import argparse
 import datetime
 import json
-import os
+import logging
 import sys
 import time
 import uuid
 
-from config import JSON_FILE, SQL_FILE, start_point, run_map
+import pytz
+import requests
+from config import BASE_TIMEZONE, JSON_FILE, SQL_FILE, run_map, start_point
 from generator.db import init_db, update_or_create_activity
 from stravaweblib import WebClient
+
+logger = logging.getLogger(__name__)
 
 # Nominatim reverse-geocoding (used by update_or_create_activity for
 # location_country) can hang indefinitely on a slow network. Give it a global
@@ -34,8 +38,10 @@ try:
     import geopy.geocoders
 
     geopy.geocoders.options.default_timeout = 10
-except Exception:
-    pass
+except ImportError:
+    # geopy is an optional dependency (only used for reverse-geocoding inside
+    # update_or_create_activity); sync proceeds without a geocoding timeout.
+    logger.debug("geopy not installed; skipping geocoder timeout guard")
 
 TRAINING_ACTIVITIES_URL = (
     "https://www.strava.com/athlete/training_activities"
@@ -122,10 +128,11 @@ class WebActivity:
 
 
 def _fmt_local_date(ts):
-    """Unix timestamp -> 'YYYY-MM-DD HH:MM:SS' (local tz)."""
+    """Unix timestamp -> 'YYYY-MM-DD HH:MM:SS' in BASE_TIMEZONE."""
     if not ts:
         return ""
-    dt = datetime.datetime.fromtimestamp(int(ts))
+    local_tz = pytz.timezone(BASE_TIMEZONE)
+    dt = datetime.datetime.fromtimestamp(int(ts), tz=datetime.UTC).astimezone(local_tz)
     return dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
@@ -148,7 +155,7 @@ def _fetch_streams(client, aid):
     headers["referer"] = f"https://www.strava.com/activities/{aid}"
     # x-csrf-token is the value of the authenticity_token param
     if csrf:
-        headers["x-csrf-token"] = list(csrf.values())[0]
+        headers["x-csrf-token"] = next(iter(csrf.values()))
     resp = client._session.get(STREAMS_URL.format(aid=aid), headers=headers)
     resp.raise_for_status()
     return resp.json()
@@ -193,7 +200,9 @@ def _sync_one(client, session, raw):
     streams = {}
     try:
         streams = _fetch_streams(client, aid)
-    except Exception as e:
+    except requests.exceptions.RequestException as e:
+        # A single activity's streams (polyline/heartrate) failing must not
+        # abort the whole sync; fall back to the list-only activity.
         print(f"  streams fail {aid}: {e}")
     act = WebActivity(raw, streams)
     created = update_or_create_activity(session, act)

--- a/run_page/strava_web_sync.py
+++ b/run_page/strava_web_sync.py
@@ -32,6 +32,7 @@ from stravaweblib import WebClient
 # timeout so the web sync never blocks forever on a single activity.
 try:
     import geopy.geocoders
+
     geopy.geocoders.options.default_timeout = 10
 except Exception:
     pass
@@ -80,7 +81,9 @@ class WebActivity:
     def __init__(self, raw, streams=None):
         self.id = int(raw["id"])
         self.name = raw.get("name", "")
-        self.type = raw.get("sport_type") or raw.get("activity_type_display_name") or "Workout"
+        self.type = (
+            raw.get("sport_type") or raw.get("activity_type_display_name") or "Workout"
+        )
         # subtype mirrors type (some generators/db layers read it, e.g. running_page)
         self.subtype = self.type
         # distance in meters
@@ -201,6 +204,7 @@ def _sync_one(client, session, raw):
 
 def _finalize(session, count):
     from generator import Generator
+
     gen = Generator(SQL_FILE)
     # running_page's Generator exposes load() (with indoor-fix logic) instead of
     # loadForMapping(); both return the list of activity dicts to write to JSON.
@@ -216,9 +220,14 @@ if __name__ == "__main__":
         description="Sync Strava activities via web endpoints (JWT session)."
     )
     parser.add_argument("jwt", help="Strava strava_remember_token JWT cookie value")
-    parser.add_argument("--days", type=int, default=7,
-                        help="number of days to look back (default: 7)")
-    parser.add_argument("--only-run", dest="only_run", action="store_true",
-                        help="only sync Run activities")
+    parser.add_argument(
+        "--days", type=int, default=7, help="number of days to look back (default: 7)"
+    )
+    parser.add_argument(
+        "--only-run",
+        dest="only_run",
+        action="store_true",
+        help="only sync Run activities",
+    )
     options = parser.parse_args()
     run_strava_web_sync(options.jwt, days=options.days, only_run=options.only_run)

--- a/run_page/strava_web_sync.py
+++ b/run_page/strava_web_sync.py
@@ -1,0 +1,224 @@
+"""Strava web-sync: pull activities via Strava's web endpoints (JWT session).
+
+Why this exists:
+    The Strava API application (OAuth2) can be in an "inactive" state, causing
+    every REST API request to return 403. The web endpoints (training_activities
+    list + per-activity streams) still work with a logged-in session (the
+    strava_remember_token JWT), so this script syncs data through those instead.
+
+Endpoints used (both verified working with a JWT session cookie):
+    GET /athlete/training_activities?page=N   -> paginated activity list
+    GET /activities/{id}/streams              -> per-activity streams (latlng, heartrate, ...)
+
+Usage:
+    python run_page/strava_web_sync.py <jwt> [--days 60] [--only-run]
+    # jwt = value of the strava_remember_token cookie (from the browser)
+"""
+
+import argparse
+import datetime
+import json
+import os
+import sys
+import time
+import uuid
+
+from config import JSON_FILE, SQL_FILE, start_point, run_map
+from generator.db import init_db, update_or_create_activity
+from stravaweblib import WebClient
+
+# Nominatim reverse-geocoding (used by update_or_create_activity for
+# location_country) can hang indefinitely on a slow network. Give it a global
+# timeout so the web sync never blocks forever on a single activity.
+try:
+    import geopy.geocoders
+    geopy.geocoders.options.default_timeout = 10
+except Exception:
+    pass
+
+TRAINING_ACTIVITIES_URL = (
+    "https://www.strava.com/athlete/training_activities"
+    "?keywords=&sport_type=&tags=&commute=&private_activities=&trainer=&gear="
+    "&search_session_id={sid}&new_activity_only=false&page={page}"
+)
+STREAMS_URL = "https://www.strava.com/activities/{aid}/streams"
+
+# Keep the list-call header set that the web client needs to return JSON models.
+LIST_HEADERS = {
+    "accept": "text/javascript, application/javascript, application/ecmascript, application/x-ecmascript",
+    "x-requested-with": "XMLHttpRequest",
+}
+
+
+def _polyline_encode(latlng_list):
+    """Encode [[lat, lng], ...] into a Google encoded polyline (matches stravalib)."""
+    if not latlng_list:
+        return ""
+    out = ""
+    prev_lat = prev_lng = 0
+    for lat, lng in latlng_list:
+        lat5 = round(lat * 1e5)
+        lng5 = round(lng * 1e5)
+        for val in (lat5 - prev_lat, lng5 - prev_lng):
+            val = (val << 1) ^ (val >> 31)
+            while val >= 0x20:
+                out += chr((0x20 | (val & 0x1F)) + 63)
+                val >>= 5
+            out += chr(val + 63)
+        prev_lat, prev_lng = lat5, lng5
+    return out
+
+
+class WebActivity:
+    """Lightweight adapter exposing the attributes update_or_create_activity needs.
+
+    Takes a raw dict from the training_activities list endpoint plus an optional
+    streams dict (from the per-activity streams endpoint) to fill in polyline,
+    heartrate and location fields.
+    """
+
+    def __init__(self, raw, streams=None):
+        self.id = int(raw["id"])
+        self.name = raw.get("name", "")
+        self.type = raw.get("sport_type") or raw.get("activity_type_display_name") or "Workout"
+        # subtype mirrors type (some generators/db layers read it, e.g. running_page)
+        self.subtype = self.type
+        # distance in meters
+        self.distance = float(raw.get("distance_raw") or 0.0)
+        # moving_time as timedelta (DB column is Interval)
+        moving_secs = int(raw.get("moving_time_raw") or 0)
+        self.moving_time = datetime.timedelta(seconds=moving_secs)
+        elapsed_secs = int(raw.get("elapsed_time_raw") or 0) or moving_secs
+        self.elapsed_time = datetime.timedelta(seconds=elapsed_secs)
+        self.start_date = raw.get("start_time", "")
+        # start_date_local_raw is a Unix timestamp -> local date string
+        self.start_date_local = _fmt_local_date(raw.get("start_date_local_raw"))
+        self.elevation_gain = raw.get("elevation_gain_raw") or 0.0
+        self.source = "strava"
+
+        # average_speed (m/s). Guard against zero moving time.
+        self.average_speed = (self.distance / moving_secs) if moving_secs else 0.0
+
+        # Fields only resolvable from the streams payload.
+        self.average_heartrate = None
+        self.summary_polyline = ""
+        self.start_latlng = None
+        if streams:
+            hr = streams.get("heartrate")
+            if hr:
+                vals = [h for h in hr if h is not None]
+                if vals:
+                    self.average_heartrate = sum(vals) / len(vals)
+            latlng = streams.get("latlng")
+            if latlng:
+                self.summary_polyline = _polyline_encode(latlng)
+                self.start_latlng = start_point(latlng[0][0], latlng[0][1])
+
+        # map attribute used by update_or_create_activity
+        self.map = run_map(self.summary_polyline)
+
+
+def _fmt_local_date(ts):
+    """Unix timestamp -> 'YYYY-MM-DD HH:MM:SS' (local tz)."""
+    if not ts:
+        return ""
+    dt = datetime.datetime.fromtimestamp(int(ts))
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _fetch_json(client, url, **extra_headers):
+    resp = client._session.get(url, headers={**LIST_HEADERS, **extra_headers})
+    resp.raise_for_status()
+    return resp.json()
+
+
+# Headers the per-activity streams endpoint requires (403 without the CSRF token).
+STREAM_HEADERS = {
+    "x-requested-with": "XMLHttpRequest",
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+}
+
+
+def _fetch_streams(client, aid):
+    csrf = client.csrf  # dict like {'authenticity_token': '...'}
+    headers = dict(STREAM_HEADERS)
+    headers["referer"] = f"https://www.strava.com/activities/{aid}"
+    # x-csrf-token is the value of the authenticity_token param
+    if csrf:
+        headers["x-csrf-token"] = list(csrf.values())[0]
+    resp = client._session.get(STREAMS_URL.format(aid=aid), headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def run_strava_web_sync(jwt, days=7, only_run=False):
+    client = WebClient(jwt=jwt)
+    print("Web login ok")
+
+    session = init_db(SQL_FILE)
+    cutoff = time.time() - days * 86400
+
+    # search_session_id: web client needs a fresh one
+    sid = str(uuid.uuid4())
+
+    page = 1
+    total_fetched = 0
+    while True:
+        data = _fetch_json(client, TRAINING_ACTIVITIES_URL.format(sid=sid, page=page))
+        models = data.get("models") or []
+        if not models:
+            break
+        for raw in models:
+            ts = raw.get("start_date_local_raw")
+            if ts and ts < cutoff:
+                # List is newest-first, so once we pass the cutoff the rest are older.
+                return _finalize(session, total_fetched)
+            if only_run and raw.get("sport_type") != "Run":
+                continue
+            _sync_one(client, session, raw)
+            total_fetched += 1
+        if page >= data.get("total", 1) // 20:
+            break
+        page += 1
+        time.sleep(0.3)  # be gentle with rate limits
+
+    return _finalize(session, total_fetched)
+
+
+def _sync_one(client, session, raw):
+    aid = int(raw["id"])
+    streams = {}
+    try:
+        streams = _fetch_streams(client, aid)
+    except Exception as e:
+        print(f"  streams fail {aid}: {e}")
+    act = WebActivity(raw, streams)
+    created = update_or_create_activity(session, act)
+    session.commit()
+    sys.stdout.write("+" if created else ".")
+    sys.stdout.flush()
+
+
+def _finalize(session, count):
+    from generator import Generator
+    gen = Generator(SQL_FILE)
+    # running_page's Generator exposes load() (with indoor-fix logic) instead of
+    # loadForMapping(); both return the list of activity dicts to write to JSON.
+    activities_list = gen.load()
+    with open(JSON_FILE, "w") as f:
+        json.dump(activities_list, f, indent=0)
+    print(f"\nDone: {count} activities synced.")
+    return count
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Sync Strava activities via web endpoints (JWT session)."
+    )
+    parser.add_argument("jwt", help="Strava strava_remember_token JWT cookie value")
+    parser.add_argument("--days", type=int, default=7,
+                        help="number of days to look back (default: 7)")
+    parser.add_argument("--only-run", dest="only_run", action="store_true",
+                        help="only sync Run activities")
+    options = parser.parse_args()
+    run_strava_web_sync(options.jwt, days=options.days, only_run=options.only_run)


### PR DESCRIPTION
## Summary

Add a new Strava sync path that works when the OAuth2 API application is inactive (all REST requests return 403), by using Strava's **web** endpoints with a logged-in session (the `strava_remember_token` JWT cookie).

### New script: `run_page/strava_web_sync.py`
- `GET /athlete/training_activities` — paginated activity list (id, name, distance, moving_time, sport_type, timestamps, elevation)
- `GET /activities/{id}/streams` — per-activity streams for `latlng` (→ summary_polyline), `heartrate`, altitude
- Reuses the existing `update_or_create_activity` storage layer via a light adapter
- Provides `subtype` (read by the generator/db layer) and uses `Generator.load()` for JSON output
- CLI: `python run_page/strava_web_sync.py <jwt> --days N [--only-run]`
- Nominatim reverse-geocoding timeout guarded so a slow network can't hang the sync

### Workflow
- Added `RUN_TYPE: strava_web` branch using `STRAVA_JWT` secret (RUN_TYPE left at `pass`; opt-in)
- Optional `STRAVA_WEB_DAYS` variable (default 7)

### Docs
- README / README-CN updated with usage, JWT retrieval, and CI setup notes

## Notes
- ⚠️ `STRAVA_JWT` secret must be configured; JWT expires ~30 days and needs periodic refresh
- No data files committed

## Tested
- Local 7-day sync verified (`Web login ok`, activities created with polyline/heartrate/speed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)